### PR TITLE
Changing how input parameters are matched to be regex instead of stri…

### DIFF
--- a/lib/GRNOC/Simp/CompData/Worker.pm
+++ b/lib/GRNOC/Simp/CompData/Worker.pm
@@ -224,26 +224,30 @@ sub _scan_cb{
   my $id          = shift;
   my $oid_pattern = shift;
   my $vals        = shift;
-  my $results     = shift; 
-
+  my $results     = shift;
+  
   $oid_pattern  =~s/\*//;
   $oid_pattern = quotemeta($oid_pattern);
-
+  
   foreach my $host (@$hosts){
       foreach my $oid (keys %{$data->{$host}}){
+	  
+	  my $base_value = $data->{$host}{$oid}{'value'};
+	  
+          # strip out the wildcard part of the oid
+	  $oid =~ s/$oid_pattern//;
+	  
+          #--- return only those entries matching specified values
 	  if(defined $vals){
-	      #--- return only those entries matching specified values
 	      foreach my $val (@$vals){
-		  if($data->{$host}{$oid}{'value'} eq $val){
-		      $oid =~ s/$oid_pattern//;
-		      $results->{$host}{$id}{$val} = $oid;
+		  if($base_value =~ /$val/){
+		      $results->{$host}{$id}{$base_value} = $oid;
 		  }
 	      }
-	  }else{
-	      #--- no val specified, return all
-	      my $val = $data->{$host}{$oid}{'value'};
-	      $oid =~ s/$oid_pattern//;
-	      $results->{$host}{$id}{$val} = $oid;
+	  }
+          #--- no val specified, return all
+	  else{
+	      $results->{$host}{$id}{$base_value} = $oid;
 	  }
       }
   }


### PR DESCRIPTION
This changes the way that input parameters are handled. Instead of doing an exact string match it now does a regular expression match. You can still enter ^$ if you want exact matches. It's technically backwards incompatible, but not sure if it matters at this point in the lifecycle.