### PR TITLE
Make host variables usable ISSUE=5460

### DIFF
--- a/lib/GRNOC/Simp/Data/Worker.pm
+++ b/lib/GRNOC/Simp/Data/Worker.pm
@@ -215,11 +215,11 @@ sub _find_group{
     my $oid = $params{'oid'};
     my $requested = $params{'requested'};
 
-    my @host_groups;
+    my %host_groups;
 
     try{
 	$self->redis->select(3);
-	@host_groups = $self->redis->smembers($host);
+	%host_groups = $self->redis->hgetall($host);
 	$self->redis->select(0);
     }catch{
 	$self->redis->select(0);
@@ -228,8 +228,8 @@ sub _find_group{
     };	
 
     my @new_host_groups;
-    foreach my $hg (@host_groups){
-	my ($base_oid, $group, $interval) = split(',', $hg);
+    foreach my $base_oid (keys %host_groups){
+	my ($group, $interval) = split(',', $host_groups{$base_oid});
 	if($oid =~ /$base_oid/){
 	    push(@new_host_groups, { base_oid => $base_oid, group => $group, interval => $interval});
 	}

--- a/lib/GRNOC/Simp/Poller/Worker.pm
+++ b/lib/GRNOC/Simp/Poller/Worker.pm
@@ -202,11 +202,11 @@ sub _poll_cb{
 		    my $str = 'vars.' . $sanitized_name . "," . $add_values{$name}->{'value'};
 		    $redis->select(0);
 		    $redis->sadd($key, $str);
-		    
-		    $redis->select(3);
-		    $redis->sadd($host->{'node_name'}, $name . "," . $self->group_name . "," . $self->poll_interval);
-		    $redis->sadd($ip, $name . "," . $self->group_name . "," . $self->poll_interval);
 		}
+
+		$redis->select(3);
+		$redis->sadd($host->{'node_name'}, "vars," . $self->group_name . "," . $self->poll_interval);
+		$redis->sadd($ip, "vars," . $self->group_name . "," . $self->poll_interval);
 	    }
 
 	    #and the current poll_id lookup

--- a/lib/GRNOC/Simp/Poller/Worker.pm
+++ b/lib/GRNOC/Simp/Poller/Worker.pm
@@ -123,6 +123,8 @@ sub start {
     
     $self->_connect_to_snmp();
 
+    $self->logger->debug($self->worker_name . ' var_hosts: "' . (join '", "', (keys $self->var_hosts)) . '"');
+
     $self->{'collector_timer'} = AnyEvent->timer( after => 10,
 						  interval => $self->poll_interval,
 						  cb => sub {
@@ -198,6 +200,9 @@ sub _poll_cb{
 	    #$self->logger->error(Dumper($host->{'group'}{$self->group_name}));
 
 	    if($self->var_hosts()->{$host->{'node_name'}} && defined($host->{'host_variable'})){
+
+                $self->logger->debug("Adding host variables for $host->{'node_name'}");
+
 		my %add_values = %{$host->{'host_variable'}};
 		foreach my $name (keys %add_values){
 		    my $sanitized_name = $name;

--- a/lib/GRNOC/Simp/Poller/Worker.pm
+++ b/lib/GRNOC/Simp/Poller/Worker.pm
@@ -197,7 +197,7 @@ sub _poll_cb{
 	    if(defined($host->{'group'}{$self->group_name}{'host_variable'})){
 		my %add_values = %{$host->{'group'}{$self->group_name}{'host_variable'}};
 		foreach my $name (keys %add_values){
-		    my $sanitzed_name = $name;
+		    my $sanitized_name = $name;
 		    $sanitized_name =~ s/,//g; # we don't allow commas in variable names
 		    my $str = 'vars.' . $sanitized_name . "," . $add_values{$name}->{'value'};
 		    $redis->select(0);

--- a/lib/GRNOC/Simp/Poller/Worker.pm
+++ b/lib/GRNOC/Simp/Poller/Worker.pm
@@ -123,7 +123,7 @@ sub start {
     
     $self->_connect_to_snmp();
 
-    $self->logger->debug($self->worker_name . ' var_hosts: "' . (join '", "', (keys $self->var_hosts)) . '"');
+    $self->logger->debug($self->worker_name . ' var_hosts: "' . (join '", "', (keys %{$self->var_hosts})) . '"');
 
     $self->{'collector_timer'} = AnyEvent->timer( after => 10,
 						  interval => $self->poll_interval,

--- a/lib/GRNOC/Simp/Poller/Worker.pm
+++ b/lib/GRNOC/Simp/Poller/Worker.pm
@@ -208,8 +208,8 @@ sub _poll_cb{
 		}
 
 		$redis->select(3);
-		$redis->sadd($host->{'node_name'}, "vars," . $self->group_name . "," . $self->poll_interval);
-		$redis->sadd($ip, "vars," . $self->group_name . "," . $self->poll_interval);
+		$redis->hset($host->{'node_name'}, "vars", $self->group_name . "," . $self->poll_interval);
+		$redis->hset($ip, "vars", $self->group_name . "," . $self->poll_interval);
 	    }
 
 	    #and the current poll_id lookup
@@ -225,8 +225,8 @@ sub _poll_cb{
 
 	
 	$redis->select(3);
-	$redis->sadd($host->{'node_name'}, $main_oid . "," . $self->group_name . "," . $self->poll_interval);
-	$redis->sadd($ip, $main_oid . "," . $self->group_name . "," . $self->poll_interval);
+	$redis->hset($host->{'node_name'}, $main_oid, $self->group_name . "," . $self->poll_interval);
+	$redis->hset($ip, $main_oid, $self->group_name . "," . $self->poll_interval);
 
 	#change back to the primary db...
 	$redis->select(0);

--- a/lib/GRNOC/Simp/Poller/Worker.pm
+++ b/lib/GRNOC/Simp/Poller/Worker.pm
@@ -194,10 +194,12 @@ sub _poll_cb{
             $redis->select(0);
 	    #$self->logger->error(Dumper($host->{'group'}{$self->group_name}));
 
-	    if(defined($host->{'group'}{$self->group_name}{'additional_value'})){
-		my %add_values = %{$host->{'group'}{$self->group_name}{'additional_value'}};
+	    if(defined($host->{'group'}{$self->group_name}{'host_variable'})){
+		my %add_values = %{$host->{'group'}{$self->group_name}{'host_variable'}};
 		foreach my $name (keys %add_values){
-		    my $str = 'vars.' . $name . "," . $add_values{$name}->{'value'};
+		    my $sanitzed_name = $name;
+		    $sanitized_name =~ s/,//g; # we don't allow commas in variable names
+		    my $str = 'vars.' . $sanitized_name . "," . $add_values{$name}->{'value'};
 		    $redis->select(0);
 		    $redis->sadd($key, $str);
 		    

--- a/lib/GRNOC/Simp/Poller/Worker.pm
+++ b/lib/GRNOC/Simp/Poller/Worker.pm
@@ -197,7 +197,7 @@ sub _poll_cb{
             $redis->select(0);
 	    #$self->logger->error(Dumper($host->{'group'}{$self->group_name}));
 
-	    if($self->host_vars()->{$host->{'node_name'}} && defined($host->{'host_variable'})){
+	    if($self->var_hosts()->{$host->{'node_name'}} && defined($host->{'host_variable'})){
 		my %add_values = %{$host->{'host_variable'}};
 		foreach my $name (keys %add_values){
 		    my $sanitized_name = $name;

--- a/lib/GRNOC/Simp/Poller/Worker.pm
+++ b/lib/GRNOC/Simp/Poller/Worker.pm
@@ -34,6 +34,9 @@ has oids => ( is => 'ro',
 has poll_interval => ( is => 'ro',
 		       required => 1 );
 
+has var_hosts => ( is => 'ro',
+                   required => 1 );
+
 
 ### internal attributes ###
 
@@ -194,8 +197,8 @@ sub _poll_cb{
             $redis->select(0);
 	    #$self->logger->error(Dumper($host->{'group'}{$self->group_name}));
 
-	    if(defined($host->{'group'}{$self->group_name}{'host_variable'})){
-		my %add_values = %{$host->{'group'}{$self->group_name}{'host_variable'}};
+	    if($self->host_vars()->{$host->{'node_name'}} && defined($host->{'host_variable'})){
+		my %add_values = %{$host->{'host_variable'}};
 		foreach my $name (keys %add_values){
 		    my $sanitized_name = $name;
 		    $sanitized_name =~ s/,//g; # we don't allow commas in variable names

--- a/lib/GRNOC/Simp/Poller/Worker.pm
+++ b/lib/GRNOC/Simp/Poller/Worker.pm
@@ -197,7 +197,7 @@ sub _poll_cb{
 	    if(defined($host->{'group'}{$self->group_name}{'additional_value'})){
 		my %add_values = %{$host->{'group'}{$self->group_name}{'additional_value'}};
 		foreach my $name (keys %add_values){
-		    my $str = $name . "," . $add_values{$name}->{'value'};
+		    my $str = 'vars.' . $name . "," . $add_values{$name}->{'value'};
 		    $redis->select(0);
 		    $redis->sadd($key, $str);
 		    


### PR DESCRIPTION
This re-works host variables (key-value pairs associated with a host) so that they can be more-easily used by, e.g., CompData.

I _have_ tested out these changes, and they appear to work as desired.