### PR TITLE
Poller: use 'node_name' as unique index for SNMP sessions; misc. fixes ISSUE=4618

### DIFF
--- a/lib/GRNOC/Simp/Poller/Worker.pm
+++ b/lib/GRNOC/Simp/Poller/Worker.pm
@@ -255,7 +255,7 @@ sub _connect_to_snmp{
 		$self->logger->error("Error creating SNMP Session: " . $error);
 	    }
 
-	    $self->{'snmp'}{$host->{'ip'}} = $snmp;
+	    $self->{'snmp'}{$host->{'node_name'}} = $snmp;
 
 	}elsif($host->{'snmp_version'} eq '3'){
 	    if(!defined($host->{'group'}{$self->group_name}{'context_id'})){
@@ -273,7 +273,7 @@ sub _connect_to_snmp{
 		    $self->logger->error("Error creating SNMP Session: " . $error);
 		}
 		
-		$self->{'snmp'}{$host->{'ip'}} = $snmp;
+		$self->{'snmp'}{$host->{'node_name'}} = $snmp;
 	    }else{
 		foreach my $ctxEngine (@{$host->{'group'}{$self->group_name}{'context_id'}}){
 		    ($snmp, $error) = Net::SNMP->session(
@@ -290,7 +290,7 @@ sub _connect_to_snmp{
 			$self->logger->error("Error creating SNMP Session: " . $error);
 		    }
 		    
-		    $self->{'snmp'}{$host->{'ip'}}{$ctxEngine} = $snmp;
+		    $self->{'snmp'}{$host->{'node_name'}}{$ctxEngine} = $snmp;
 		}
 	    }
 	}else{
@@ -316,7 +316,7 @@ sub _connect_to_snmp{
 	$host->{'poll_id'} = $host_poll_id;
 	$host->{'pending_replies'} = {};
 	
-	$self->logger->debug($self->worker_name . " assigned host " . $host->{'ip'});
+	$self->logger->debug($self->worker_name . " assigned host " . $host->{'node_name'});
     }
 }
 
@@ -331,23 +331,23 @@ sub _collect_data{
     for my $host (@$hosts){
 
 	if(scalar(keys %{$host->{'pending_replies'}}) > 0){
-	    $self->logger->error("Unable to query device " . $host->{'ip'} . ":" . $host->{'name'} . " in poll cycle for group: " . $self->group_name);
+	    $self->logger->error("Unable to query device " . $host->{'ip'} . ":" . $host->{'node_name'} . " in poll cycle for group: " . $self->group_name);
 	    next;
 	}
 
 	for my $oid (@$oids){
-	    if(!defined($self->{'snmp'}{$host->{'ip'}})){
-		$self->logger->error("No SNMP session defined for " . $host->{'ip'});
+	    if(!defined($self->{'snmp'}{$host->{'node_name'}})){
+		$self->logger->error("No SNMP session defined for " . $host->{'node_name'});
 		next;
 	    }
-	    my $reqstr = " $oid -> ".$host->{'ip'};
+	    my $reqstr = " $oid -> $host->{'ip'} ($host->{'node_name'})";
 	    $self->logger->debug($self->worker_name ." requesting ". $reqstr);
 	    #--- iterate through the the provided set of base OIDs to collect
 	    my $res;
 
 	    if($host->{'snmp_version'} eq '2c'){
 		$host->{'pending_replies'}->{$oid} = 1;
-		$res = $self->{'snmp'}{$host->{'ip'}}->get_table(
+		$res = $self->{'snmp'}{$host->{'node_name'}}->get_table(
 		    -baseoid      => $oid,
 		    -maxrepetitions => $self->max_reps,
 		    -callback     => sub{ 
@@ -363,7 +363,7 @@ sub _collect_data{
 		#for each context engine specified for the group
 		if(!defined($host->{'group'}{$self->group_name}{'context_id'})){
 		    $host->{'pending_replies'}->{$oid} = 1;
-		    $res = $self->{'snmp'}{$host->{'ip'}}->get_table(
+		    $res = $self->{'snmp'}{$host->{'node_name'}}->get_table(
 			-baseoid      => $oid,
 			-maxrepetitions => $self->max_reps,
 			-callback     => sub{
@@ -379,7 +379,7 @@ sub _collect_data{
 		}else{
 		    foreach my $ctxEngine (@{$host->{'group'}{$self->group_name}{'context_id'}}){
 			$host->{'pending_replies'}->{$oid . "," . $ctxEngine} = 1;
-			$res = $self->{'snmp'}{$host->{'ip'}}{$ctxEngine}->get_table(
+			$res = $self->{'snmp'}{$host->{'node_name'}}{$ctxEngine}->get_table(
 			    -baseoid      => $oid,
 			    -maxrepetitions => $self->max_reps,
 			    -contextengineid => $ctxEngine,

--- a/lib/GRNOC/Simp/Poller/Worker.pm
+++ b/lib/GRNOC/Simp/Poller/Worker.pm
@@ -158,7 +158,7 @@ sub _poll_cb{
 
     if(!defined $data){
 	my $error = $session->error();
-	$self->logger->error("Context ID: " . $context_id);
+	$self->logger->error("Host/Context ID: $host->{'node_name'} " . (defined($context_id) ? $context_id : '[no context ID]'));
 	$self->logger->error("$id failed     $reqstr");
 	$self->logger->error("Error: $error");
 


### PR DESCRIPTION
In some use-cases, we'll have multiple entries in `hosts.xml` with the same IP address but different SNMP community strings, etc. Currently, we index SNMP sessions inside a Simp poller by IP address, which doesn't work in these scenarios — a session for one entry will get replaced by a session for another.

I'm told that we _can_ safely assume that the `node_name` attribute of `<host>` in `hosts.xml` is unique. This pull request switches the poller to use `node_name` to index sessions.