### PR TITLE
Improved change-uid logic in simp-{poller,data,comp} ISSUE=6479

### DIFF
--- a/bin/simp-comp.pl
+++ b/bin/simp-comp.pl
@@ -7,7 +7,7 @@ use Getopt::Long;
 use GRNOC::Simp::CompData;
 
 sub usage {
-    print "Usage: $0 [--config <file path>] [--logging <file path>] [--nofork]\n";
+    print "Usage: $0 [--config <file path>] [--logging <file path>] [--nofork] [--user <user name>] [--group <group name>]\n";
     exit( 1 );
 }
 
@@ -19,11 +19,15 @@ my $config_file = DEFAULT_CONFIG_FILE;
 my $logging     = DEFAULT_LOG_FILE;
 my $nofork;
 my $help;
+my $username;
+my $groupname;
 
-GetOptions( 'config=s' => \$config_file,
- 	    'logging=s' => \$logging,
-	    'nofork' => \$nofork,
-            'help|h|?' => \$help );
+GetOptions( 'config=s'  => \$config_file,
+            'logging=s' => \$logging,
+            'nofork'    => \$nofork,
+            'user=s'    => \$username,
+            'group=s'   => \$groupname,
+            'help|h|?'  => \$help );
 
 usage() if $help;
 
@@ -31,6 +35,8 @@ usage() if $help;
 my $data_services = GRNOC::Simp::CompData->new(
 			config_file    => $config_file,
                         logging_file   => $logging,
+                        run_user       => $username,
+                        run_group      => $groupname,
 			daemonize      => !$nofork );
 
 $data_services->start();

--- a/bin/simp-comp.pl
+++ b/bin/simp-comp.pl
@@ -7,7 +7,11 @@ use Getopt::Long;
 use GRNOC::Simp::CompData;
 
 sub usage {
-    print "Usage: $0 [--config <file path>] [--logging <file path>] [--nofork] [--user <user name>] [--group <group name>]\n";
+    my $text = <<"EOM";
+Usage: $0 [--config <file path>] [--logging <file path>]
+    [--nofork] [--user <user name>] [--group <group name>]
+EOM
+    print $text;
     exit( 1 );
 }
 

--- a/bin/simp-data.pl
+++ b/bin/simp-data.pl
@@ -7,7 +7,11 @@ use Getopt::Long;
 use GRNOC::Simp::Data;
 
 sub usage {
-    print "Usage: $0 [--config <file path>] [--logging <file path>] [--nofork] [--user <user name>] [--group <group name>]\n";
+    my $text = <<"EOM";
+Usage: $0 [--config <file path>] [--logging <file path>]
+    [--nofork] [--user <user name>] [--group <group name>]
+EOM
+    print $text;
     exit( 1 );
 }
 

--- a/bin/simp-data.pl
+++ b/bin/simp-data.pl
@@ -7,7 +7,7 @@ use Getopt::Long;
 use GRNOC::Simp::Data;
 
 sub usage {
-    print "Usage: $0 [--config <file path>] [--logging <file path>] [--nofork]\n";
+    print "Usage: $0 [--config <file path>] [--logging <file path>] [--nofork] [--user <user name>] [--group <group name>]\n";
     exit( 1 );
 }
 
@@ -19,11 +19,15 @@ my $config_file = DEFAULT_CONFIG_FILE;
 my $logging     = DEFAULT_LOG_FILE;
 my $nofork;
 my $help;
+my $username;
+my $groupname;
 
-GetOptions( 'config=s' => \$config_file,
- 	    'logging=s' => \$logging,
-	    'nofork' => \$nofork,
-            'help|h|?' => \$help );
+GetOptions( 'config=s'  => \$config_file,
+            'logging=s' => \$logging,
+            'nofork'    => \$nofork,
+            'user=s'    => \$username,
+            'group=s'   => \$groupname,
+            'help|h|?'  => \$help );
 
 usage() if $help;
 
@@ -31,6 +35,8 @@ usage() if $help;
 my $data_services = GRNOC::Simp::Data->new(
 			config_file    => $config_file,
                         logging_file   => $logging,
+                        run_user       => $username,
+                        run_group      => $groupname,
 			daemonize      => !$nofork );
 
 $data_services->start();

--- a/bin/simp-poller.pl
+++ b/bin/simp-poller.pl
@@ -10,7 +10,12 @@ use Getopt::Long;
 use GRNOC::Simp::Poller;
 
 sub usage {
-    print "Usage: $0 [--config <file path>]  [--hosts <file path>] [--logging <file path>] [--nofork] [--user <user name>] [--group <group name>]\n";
+    my $text = <<"EOM";
+Usage: $0 [--config <file path>]  [--hosts <file path>]
+    [--logging <file path>] [--nofork]
+    [--user <user name>] [--group <group name>]
+EOM
+    print $text;
     exit( 1 );
 }
 

--- a/bin/simp-poller.pl
+++ b/bin/simp-poller.pl
@@ -10,7 +10,7 @@ use Getopt::Long;
 use GRNOC::Simp::Poller;
 
 sub usage {
-    print "Usage: $0 [--config <file path>]  [--hosts <file path>] [--logging <file path>] [--nofork]\n";
+    print "Usage: $0 [--config <file path>]  [--hosts <file path>] [--logging <file path>] [--nofork] [--user <user name>] [--group <group name>]\n";
     exit( 1 );
 }
 
@@ -24,11 +24,15 @@ my $hosts_file  = DEFAULT_HOSTS_FILE;
 my $logging     = DEFAULT_LOGGING_FILE;
 my $nofork;
 my $help;
+my $username;
+my $groupname;
 
 GetOptions( 'config=s'  => \$config_file,
             'hosts=s'   => \$hosts_file,
  	    'logging=s' => \$logging,
 	    'nofork'    => \$nofork,
+	    'user=s'    => \$username,
+	    'group=s'   => \$groupname,
             'help|h|?'  => \$help ) 
 
 or usage();
@@ -40,6 +44,8 @@ my $poller = GRNOC::Simp::Poller->new(
 			config_file    => $config_file,
                         hosts_file     => $hosts_file,
                         logging_file   => $logging,
+                        run_user       => $username,
+                        run_group      => $groupname,
 			daemonize      => !$nofork );
 
 $poller->start();

--- a/conf/simp-poller.init
+++ b/conf/simp-poller.init
@@ -24,8 +24,9 @@ name=simp-poller.pl
 exec_file=/usr/bin/$name
 options=""
 username=simp
+group=simp
 lockfile=/var/lock/subsys/$name
-command="$exec_file $options"
+command="$exec_file $options --user ${username} --group ${group}"
 PIDFILE=/var/run/simp_poller.pid
 
 start() {

--- a/conf/simp_comp.init
+++ b/conf/simp_comp.init
@@ -24,8 +24,9 @@ name=simp-comp.pl
 exec_file=/usr/bin/$name
 options=""
 username=simp
+group=simp
 lockfile=/var/lock/subsys/$name
-command="$exec_file $options"
+command="$exec_file $options --user ${username} --group ${group}"
 PIDFILE=/var/run/simp_comp.pid
 
 start() {

--- a/conf/simp_data.init
+++ b/conf/simp_data.init
@@ -24,8 +24,9 @@ name=simp-data.pl
 exec_file=/usr/bin/$name
 options=""
 username=simp
+group=simp
 lockfile=/var/lock/subsys/$name
-command="$exec_file $options"
+command="$exec_file $options --user ${username} --group ${group}"
 PIDFILE=/var/run/simp_data.pid
 
 start() {

--- a/lib/GRNOC/Simp/CompData.pm
+++ b/lib/GRNOC/Simp/CompData.pm
@@ -7,6 +7,7 @@ use Types::Standard qw( Str Bool );
 
 use Parallel::ForkManager;
 use Proc::Daemon;
+use POSIX qw( setuid setgid );
 
 our $VERSION='1.0.6';
 
@@ -150,10 +151,10 @@ sub start {
             my $groupname = $self->run_group;
 
             my $gid = (defined($groupname)) ? getgrnam($groupname) : undef;
-            $) = $gid if defined($gid);
+            setgid($gid) if defined($gid);
 
             my $uid = (defined($username)) ? getpwnam($username) : undef;
-            $> = $uid if defined($uid);
+            setuid($uid) if defined($uid);
 
             $self->_create_workers();
         }

--- a/lib/GRNOC/Simp/CompData.pm
+++ b/lib/GRNOC/Simp/CompData.pm
@@ -26,6 +26,10 @@ use GRNOC::Simp::CompData::Worker;
 
 =item daemonize
 
+=item run_user
+
+=item run_group
+
 =back
 
 =cut
@@ -43,6 +47,12 @@ has logging_file => ( is => 'ro',
 has daemonize => ( is => 'ro',
                    isa => Bool,
                    default => 1 );
+
+has run_user => ( is => 'ro',
+                  required => 0 );
+
+has run_group => ( is => 'ro',
+                   required => 0 );
 
 ### private attributes ###
 =head2 private attributes
@@ -135,8 +145,15 @@ sub start {
             # change process name
             $0 = "CompData";
 
-            my $uid = getpwnam('simp');
-            $> = $uid;
+            # figure out what user/group (if any) to change to
+            my $username  = $self->run_user;
+            my $groupname = $self->run_group;
+
+            my $gid = (defined($groupname)) ? getgrnam($groupname) : undef;
+            $) = $gid if defined($gid);
+
+            my $uid = (defined($username)) ? getpwnam($username) : undef;
+            $> = $uid if defined($uid);
 
             $self->_create_workers();
         }

--- a/lib/GRNOC/Simp/CompData.pm
+++ b/lib/GRNOC/Simp/CompData.pm
@@ -147,14 +147,26 @@ sub start {
             $0 = "CompData";
 
             # figure out what user/group (if any) to change to
-            my $username  = $self->run_user;
-            my $groupname = $self->run_group;
+            my $user_name  = $self->run_user;
+            my $group_name = $self->run_group;
 
-            my $gid = (defined($groupname)) ? getgrnam($groupname) : undef;
-            setgid($gid) if defined($gid);
+            if (defined($group_name)) {
+                my $gid = getgrnam($group_name);
+                $self->_log_err_then_exit("Unable to get GID for group '$group_name'") if !defined($gid);
 
-            my $uid = (defined($username)) ? getpwnam($username) : undef;
-            setuid($uid) if defined($uid);
+                $! = 0;
+                setgid($gid);
+                $self->_log_err_then_exit("Unable to set GID to $gid ($group_name)") if $! != 0;
+            }
+
+            if (defined($user_name)) {
+                my $uid = getpwnam($user_name);
+                $self->_log_err_then_exit("Unable to get UID for user '$user_name'") if !defined($uid);
+
+                $! = 0;
+                setuid($uid);
+                $self->_log_err_then_exit("Unable to set UID to $uid ($user_name)") if $! != 0;
+            }
 
             $self->_create_workers();
         }
@@ -175,6 +187,15 @@ sub start {
     }
 
     return 1;
+}
+
+sub _log_err_then_exit {
+    my $self = shift;
+    my $msg  = shift;
+
+    $self->logger->error($msg);
+    warn "$msg\n";
+    exit 1;
 }
 
 =head2 stop

--- a/lib/GRNOC/Simp/Data.pm
+++ b/lib/GRNOC/Simp/Data.pm
@@ -7,6 +7,7 @@ use Types::Standard qw( Str Bool );
 
 use Parallel::ForkManager;
 use Proc::Daemon;
+use POSIX qw( setuid setgid );
 
 use GRNOC::Config;
 use GRNOC::Log;
@@ -151,10 +152,10 @@ sub start {
             my $groupname = $self->run_group;
 
             my $gid = (defined($groupname)) ? getgrnam($groupname) : undef;
-            $) = $gid if defined($gid);
+            setgid($gid) if defined($gid);
 
             my $uid = (defined($username)) ? getpwnam($username) : undef;
-            $> = $uid if defined($uid);
+            setuid($uid) if defined($uid);
 
             $self->_create_workers();
         }

--- a/lib/GRNOC/Simp/Data.pm
+++ b/lib/GRNOC/Simp/Data.pm
@@ -26,6 +26,10 @@ use GRNOC::Simp::Data::Worker;
 
 =item daemonize
 
+=item run_user
+
+=item run_group
+
 =back
 
 =cut
@@ -43,6 +47,12 @@ has logging_file => ( is => 'ro',
 has daemonize => ( is => 'ro',
                    isa => Bool,
                    default => 1 );
+
+has run_user => ( is => 'ro',
+                  required => 0 );
+
+has run_group => ( is => 'ro',
+                   required => 0 );
 
 ### private attributes ###
 =head2 private attributes
@@ -136,8 +146,15 @@ sub start {
             # change process name
             $0 = "SimpData";
 
-            my $uid = getpwnam('simp');
-            $> = $uid;
+            # figure out what user/group (if any) to change to
+            my $username  = $self->run_user;
+            my $groupname = $self->run_group;
+
+            my $gid = (defined($groupname)) ? getgrnam($groupname) : undef;
+            $) = $gid if defined($gid);
+
+            my $uid = (defined($username)) ? getpwnam($username) : undef;
+            $> = $uid if defined($uid);
 
             $self->_create_workers();
         }

--- a/lib/GRNOC/Simp/Poller.pm
+++ b/lib/GRNOC/Simp/Poller.pm
@@ -8,6 +8,7 @@ use Types::Standard qw( Str Bool );
 
 use Parallel::ForkManager;
 use Proc::Daemon;
+use POSIX qw( setuid setgid );
 
 use GRNOC::Config;
 use GRNOC::Log;
@@ -202,10 +203,10 @@ sub start {
             my $groupname = $self->run_group;
 
             my $gid = (defined($groupname)) ? getgrnam($groupname) : undef;
-            $) = $gid if defined($gid);
+            setgid($gid) if defined($gid);
 
             my $uid = (defined($username)) ? getpwnam($username) : undef;
-            $> = $uid if defined($uid);
+            setuid($uid) if defined($uid);
 
             $self->_create_workers();
         }

--- a/lib/GRNOC/Simp/Poller.pm
+++ b/lib/GRNOC/Simp/Poller.pm
@@ -30,6 +30,10 @@ use GRNOC::Simp::Poller::Worker;
 
 =item daemonize
 
+=item run_user
+
+=item run_group
+
 =back
 
 =cut
@@ -51,6 +55,12 @@ has logging_file => ( is => 'ro',
 has daemonize => ( is => 'ro',
                    isa => Bool,
                    default => 1 );
+
+has run_user => ( is => 'ro',
+                  required => 0 );
+
+has run_group => ( is => 'ro',
+                   required => 0 );
 
 ### private attributes ###
 
@@ -186,8 +196,17 @@ sub start {
             
             # change process name
             $0 = "simpPoller";
-            my $uid = getpwnam('simp');
-            $> = $uid;
+
+            # figure out what user/group (if any) to change to
+            my $username  = $self->run_user;
+            my $groupname = $self->run_group;
+
+            my $gid = (defined($groupname)) ? getgrnam($groupname) : undef;
+            $) = $gid if defined($gid);
+
+            my $uid = (defined($username)) ? getpwnam($username) : undef;
+            $> = $uid if defined($uid);
+
             $self->_create_workers();
         }
     }

--- a/lib/GRNOC/Simp/Poller.pm
+++ b/lib/GRNOC/Simp/Poller.pm
@@ -199,14 +199,26 @@ sub start {
             $0 = "simpPoller";
 
             # figure out what user/group (if any) to change to
-            my $username  = $self->run_user;
-            my $groupname = $self->run_group;
+            my $user_name  = $self->run_user;
+            my $group_name = $self->run_group;
 
-            my $gid = (defined($groupname)) ? getgrnam($groupname) : undef;
-            setgid($gid) if defined($gid);
+            if (defined($group_name)) {
+                my $gid = getgrnam($group_name);
+                $self->_log_err_then_exit("Unable to get GID for group '$group_name'") if !defined($gid);
 
-            my $uid = (defined($username)) ? getpwnam($username) : undef;
-            setuid($uid) if defined($uid);
+                $! = 0;
+                setgid($gid);
+                $self->_log_err_then_exit("Unable to set GID to $gid ($group_name)") if $! != 0;
+            }
+
+            if (defined($user_name)) {
+                my $uid = getpwnam($user_name);
+                $self->_log_err_then_exit("Unable to get UID for user '$user_name'") if !defined($uid);
+
+                $! = 0;
+                setuid($uid);
+                $self->_log_err_then_exit("Unable to set UID to $uid ($user_name)") if $! != 0;
+            }
 
             $self->_create_workers();
         }
@@ -221,6 +233,15 @@ sub start {
     }
 
     return 1;
+}
+
+sub _log_err_then_exit {
+    my $self = shift;
+    my $msg  = shift;
+
+    $self->logger->error($msg);
+    warn "$msg\n";
+    exit 1;
 }
 
 =head2 stop

--- a/simp-comp.spec
+++ b/simp-comp.spec
@@ -21,6 +21,7 @@ Requires: perl-GRNOC-Config
 Requires: perl-GRNOC-RabbitMQ >= 1.1.1
 Requires: perl-Moo
 Requires: perl-Parallel-ForkManager
+Requires: perl(POSIX)
 Requires: perl-Try-Tiny
 Requires: perl-Type-Tiny
 

--- a/simp-data.spec
+++ b/simp-data.spec
@@ -22,6 +22,7 @@ Requires: perl-GRNOC-Config
 Requires: perl-GRNOC-RabbitMQ >= 1.1.1
 Requires: perl-Moo
 Requires: perl-Parallel-ForkManager
+Requires: perl(POSIX)
 Requires: perl-Redis >= 1.991
 Requires: perl-Try-Tiny
 Requires: perl-Type-Tiny

--- a/simp-poller.spec
+++ b/simp-poller.spec
@@ -22,6 +22,7 @@ Requires: perl-GRNOC-Config
 Requires: perl-Moo
 Requires: perl-Net-SNMP
 Requires: perl-Parallel-ForkManager
+Requires: perl(POSIX)
 Requires: perl-Redis >= 1.991
 Requires: perl-Try-Tiny
 Requires: perl-Type-Tiny


### PR DESCRIPTION
Instead of always trying to change to a hard-coded username, we now take `--user` and `--group` command-line arguments, neither of which is required.