### PR TITLE
Ability to exclude composites based on scan results ISSUE=6258

### DIFF
--- a/lib/GRNOC/Simp/CompData/Worker.pm
+++ b/lib/GRNOC/Simp/CompData/Worker.pm
@@ -155,6 +155,8 @@ sub _start {
     $self->config->{'force_array'} = 1; 
     my $allowed_methods = $self->config->get( '/config/composite' );
 
+    my %predefined_param = map { $_ => 1 } ('node', 'period', 'exclude_regexp');
+
     foreach my $meth (@$allowed_methods){
       my $method_id = $meth->{'id'};
       print "$method_id:\n";
@@ -176,12 +178,18 @@ sub _start {
 				    multiple => 0,
 				    pattern => $GRNOC::WebService::Regex::ANY_NUMBER);
 
+      $method->add_input_parameter( name => 'exclude_regexp',
+				    description => 'a set of var=regexp pairs, where if scan variable var matches the regexp, we exclude it from the results',
+				    required => 0,
+				    multiple => 1,
+				    pattern => '^[^=]+=.*$');
+
       #--- let xpath do the iteration for us
       my $path = "/config/composite[\@id=\"$method_id\"]/input";
       my $inputs = $self->config->get($path);
       foreach my $input (@$inputs){
         my $input_id = $input->{'id'};
-        next if ($input_id eq 'node') || ($input_id eq 'period');
+        next if $predefined_param{$input_id};
         my $required = 0;
         if(defined $input->{'required'}){$required = 1;}
 

--- a/lib/GRNOC/Simp/CompData/Worker.pm
+++ b/lib/GRNOC/Simp/CompData/Worker.pm
@@ -17,7 +17,7 @@ use GRNOC::WebService::Regex;
 
 
 ### required attributes ###
-=head1 public attrbibutes
+=head1 public attributes
 
 =over 12
 

--- a/lib/GRNOC/Simp/CompData/Worker.pm
+++ b/lib/GRNOC/Simp/CompData/Worker.pm
@@ -182,7 +182,7 @@ sub _start {
 				    description => 'a set of var=regexp pairs, where if scan variable var matches the regexp, we exclude it from the results',
 				    required => 0,
 				    multiple => 1,
-				    pattern => '^[^=]+=.*$');
+				    pattern => '^([^=]+=.*)$');
 
       #--- let xpath do the iteration for us
       my $path = "/config/composite[\@id=\"$method_id\"]/input";
@@ -322,7 +322,7 @@ sub _do_scans{
 
   # find the set of exclude patterns, and group them by var
   my %exclude_patterns;
-  foreach my $pattern (@{$params->{'exclude_regexp'}{'value'}){
+  foreach my $pattern (@{$params->{'exclude_regexp'}{'value'}}){
       $pattern =~ /^([^=]+)=(.*)$/;
       push @{$exclude_patterns{$1}}, $2;
   }
@@ -650,7 +650,7 @@ sub _do_functions{
     foreach my $host (keys %{$results->{'val'}}){
         foreach my $oid_suffix (keys %{$results->{'val'}{$host}}){
             if ($results->{'scan-exclude'}{$host}{$oid_suffix}){
-                delete $results->{'val'}{$host}{$oid_suffix};
+                delete $results->{'final'}{$host}{$oid_suffix};
             }
         }
     }

--- a/t/43-comp.t
+++ b/t/43-comp.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 90;
+use Test::More tests => 94;
 
 use GRNOC::RabbitMQ::Client;
 use Test::Deep qw(cmp_deeply num any code);
@@ -865,6 +865,37 @@ check_response(23, $response,
           'cd' => '1',
           'x' => 'd.example.net/1/',
           'time' => any(100112, code(\&is_timestampy)),
+        },
+      },
+    }
+);
+
+# Request 24: test out a simple use of exclude_regexp
+$response = $client->test10(
+    node => ['a.example.net', 'c.example.net_2'],
+    exclude_regexp => 'cpuName=U2',
+);
+
+# Notice no "CPU2/3" or "CPU2"
+check_response(24, $response,
+    {
+      'a.example.net' => {
+        '1.1' => {
+          'n' => 'a.example.net',
+          'cpu' => 'CPU1/1',
+          'time' => 100135,
+        },
+        '1.2' => {
+          'n' => 'a.example.net',
+          'cpu' => 'CPU1/2',
+          'time' => 100135,
+        },
+      },
+      'c.example.net_2' => {
+        '1' => {
+          'n' => 'c.example.net_2',
+          'cpu' => 'CPU1',
+          'time' => 100100,
         },
       },
     }

--- a/t/43-comp.t
+++ b/t/43-comp.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 94;
+use Test::More tests => 114;
 
 use GRNOC::RabbitMQ::Client;
 use Test::Deep qw(cmp_deeply num any code);
@@ -896,6 +896,132 @@ check_response(24, $response,
           'n' => 'c.example.net_2',
           'cpu' => 'CPU1',
           'time' => 100100,
+        },
+      },
+    }
+);
+
+# Request 25: test out an exclude_regexp that doesn't match anything
+$response = $client->test10(
+  node => ['b.example.net', 'd.example.net'],
+  exclude_regexp => 'cpuName=xyzzy',
+);
+
+check_response(25, $response,
+    {
+      'b.example.net' => {
+        '2' => {
+          'n' => 'b.example.net',
+          'cpu' => 'CPU2',
+          'time' => 100110,
+        },
+      },
+      'd.example.net' => {
+        '100' => {
+          'n' => 'd.example.net',
+          'cpu' => 'CPU1',
+          'time' => 100112,
+        },
+        '101' => {
+          'n' => 'd.example.net',
+          'cpu' => 'CPU2',
+          'time' => 100112,
+        },
+      },
+    }
+);
+
+# Request 26: test out multiple instances of exclude_regexp
+$response = $client->test10(
+  node => ['a.example.net'],
+  exclude_regexp => ['cpuName=/1', 'cpuName=/3'],
+);
+
+# No "CPU1/1" or "CPU2/3"
+check_response(26, $response,
+    {
+      'a.example.net' => {
+        '1.2' => {
+          'n' => 'a.example.net',
+          'cpu' => 'CPU1/2',
+          'time' => 100135,
+        },
+      },
+    }
+);
+
+# Request 27: test out exclude_regexp using a var that isn't a request parameter
+$response = $client->test10(
+  node => ['a.example.net', 'b.example.net'],
+  exclude_regexp => 'cpuExclude=2$',
+);
+
+# No "CPU1/1" or "CPU2/3"
+check_response(27, $response,
+    {
+      'a.example.net' => {
+        '1.1' => {
+          'n' => 'a.example.net',
+          'cpu' => 'CPU1/1',
+          'time' => 100135,
+        },
+        '2.3' => {
+          'n' => 'a.example.net',
+          'cpu' => 'CPU2/3',
+          'time' => 100135,
+        },
+      },
+      'b.example.net' => {
+      },
+    }
+);
+
+# Request 28: test out exclude_regexp using matches on multiple vars
+$response = $client->test10(
+  node => ['a.example.net', 'd.example.net'],
+  exclude_regexp => ['cpuExclude=1/', 'cpuName=2$'],
+);
+
+check_response(28, $response,
+    {
+      'a.example.net' => {
+        '2.3' => {
+          'n' => 'a.example.net',
+          'cpu' => 'CPU2/3',
+          'time' => 100135,
+        },
+      },
+      'd.example.net' => {
+        '100' => {
+          'n' => 'd.example.net',
+          'cpu' => 'CPU1',
+          'time' => 100112,
+        },
+      },
+    }
+);
+
+# Request 29: interaction between exclude_regexp and input vars
+$response = $client->test11(
+  node => ['a.example.net', 'd.example.net'],
+  cpuName => 'CPU1',
+  exclude_regexp => ['cpuName=2$'],
+);
+
+check_response(29, $response,
+    {
+      'a.example.net' => {
+        '1.1' => {
+          'n' => 'a.example.net',
+          'cpu' => 'CPU1/1',
+          'time' => 100135,
+        },
+      },
+      'd.example.net' => {
+        '100' => {
+          'n' => 'd.example.net',
+          'cpu' => 'CPU1',
+          'time' => 100112,
         },
       },
     }

--- a/t/43-comp.t
+++ b/t/43-comp.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 118;
+use Test::More tests => 124;
 
 use GRNOC::RabbitMQ::Client;
 use Test::Deep qw(cmp_deeply num any code);
@@ -1054,3 +1054,21 @@ check_response(30, $response,
       },
     }
 );
+
+# Request 31: a request with an invalid exclude_regexp
+$response = $client->test10(
+  node => ['a.example.net', 'd.example.net'],
+  exclude_regexp => ['cpuName'],
+);
+
+error_expected(31, $response);
+
+
+# Request 32: a request with another invalid exclude_regexp
+# (after a valid one)
+$response = $client->test10(
+  node => ['a.example.net', 'd.example.net'],
+  exclude_regexp => ['cpuExclude=x', '=2$'],
+);
+
+error_expected(32, $response);

--- a/t/43-comp.t
+++ b/t/43-comp.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 114;
+use Test::More tests => 118;
 
 use GRNOC::RabbitMQ::Client;
 use Test::Deep qw(cmp_deeply num any code);
@@ -1001,7 +1001,8 @@ check_response(28, $response,
     }
 );
 
-# Request 29: interaction between exclude_regexp and input vars
+# Request 29: interaction between an input var and an exclude_regexp
+# using the same var
 $response = $client->test11(
   node => ['a.example.net', 'd.example.net'],
   cpuName => 'CPU1',
@@ -1009,6 +1010,33 @@ $response = $client->test11(
 );
 
 check_response(29, $response,
+    {
+      'a.example.net' => {
+        '1.1' => {
+          'n' => 'a.example.net',
+          'cpu' => 'CPU1/1',
+          'time' => 100135,
+        },
+      },
+      'd.example.net' => {
+        '100' => {
+          'n' => 'd.example.net',
+          'cpu' => 'CPU1',
+          'time' => 100112,
+        },
+      },
+    }
+);
+
+# Request 30: like Request 29, but with a supplementary variable
+# in the composite as well; should have the same results
+$response = $client->test10(
+  node => ['a.example.net', 'd.example.net'],
+  cpuName => 'CPU1',
+  exclude_regexp => ['cpuName=2$'],
+);
+
+check_response(30, $response,
     {
       'a.example.net' => {
         '1.1' => {

--- a/t/conf/compDataConfig.xml.in
+++ b/t/conf/compDataConfig.xml.in
@@ -181,6 +181,22 @@
     </instance>
   </composite>
 
+  <!-- tests of exclude functionality -->
+  <composite id="test10">
+    <input id="node" required="1" />
+    <input id="cpuName" />
+
+    <instance id="genericX" hostType="default">
+      <scan id="cpuIdx" oid="2.10.9994.27.1.*" var="cpuName" />
+      <scan id="altIdx" oid="2.10.9994.27.1.*" var="cpuExclude" />
+
+      <result>
+        <val id="n" var="node" />
+        <val id="cpu" oid="2.10.9994.27.1.cpuIdx" />
+      </result>
+    </instance>
+  </composite>
+
   <composite id="interface">
     <input id="node" required="1" />
     <input id="ifName" />

--- a/t/conf/compDataConfig.xml.in
+++ b/t/conf/compDataConfig.xml.in
@@ -188,7 +188,9 @@
 
     <instance id="genericX" hostType="default">
       <scan id="cpuIdx" oid="2.10.9994.27.1.*" var="cpuName" />
-      <scan id="altIdx" oid="2.10.9994.27.1.*" var="cpuExclude" />
+      <!-- exclude-only means that we don't add OID matches based on this scan,
+           but it can be used for exclusions -->
+      <scan id="altIdx" oid="2.10.9994.27.1.*" var="cpuExclude" exclude-only="1" />
 
       <result>
         <val id="n" var="node" />

--- a/t/conf/compDataConfig.xml.in
+++ b/t/conf/compDataConfig.xml.in
@@ -197,6 +197,21 @@
     </instance>
   </composite>
 
+  <!-- another, slightly different test of exclude functionality -->
+  <composite id="test11">
+    <input id="node" required="1" />
+    <input id="cpuName" />
+
+    <instance id="genericX" hostType="default">
+      <scan id="cpuIdx" oid="2.10.9994.27.1.*" var="cpuName" />
+
+      <result>
+        <val id="n" var="node" />
+        <val id="cpu" oid="2.10.9994.27.1.cpuIdx" />
+      </result>
+    </instance>
+  </composite>
+
   <composite id="interface">
     <input id="node" required="1" />
     <input id="ifName" />


### PR DESCRIPTION
The use-case that motivated this work is that we'd like to be able to say "return information on all interfaces, _except_ for those whose `ifAlias` entry matches some pattern". Now, you can add

```xml
  <scan id="someId" oid="1.3.6.1.2.1.31.1.1.1.18.*" var="descr" exclude-only="1" />
```

to the composite and use `exclude_regexp: 'descr=[`_`some regular expression`_`]'` in a request to use the scan for filtering.