### PR TITLE
Make simp-poller report status information ISSUE=6706

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 /pm_to_blib
 /simp-*.tar
 /simp-*.tar.gz
+/dist
+/tap
+/cover_db
 
 # Files generated during tests
 /t/conf/*DataConfig.xml

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ VERSION=1.0.6
 
 rpm:	dist
 	rpmbuild -ta dist/simp-poller-$(VERSION).tar.gz
+	rpmbuild -ta dist/poller-config-$(VERSION).tar.gz
 	rpmbuild -ta dist/simp-data-$(VERSION).tar.gz
 	rpmbuild -ta dist/simp-comp-$(VERSION).tar.gz
 	rpmbuild -ta dist/simp-tsds-$(VERSION).tar.gz
@@ -29,10 +30,12 @@ dist:
 	mkdir -p dist/simp-poller-$(VERSION)/lib/GRNOC/Simp
 	mkdir -p dist/simp-poller-$(VERSION)/bin
 	mkdir -p dist/simp-poller-$(VERSION)/conf/hosts.d
+	mkdir -p dist/poller-config-$(VERSION)/lib/GRNOC/Simp/Poller
 	mkdir -p dist/simp-tsds-$(VERSION)/lib/GRNOC/Simp
 	mkdir -p dist/simp-tsds-$(VERSION)/bin
 	mkdir -p dist/simp-tsds-$(VERSION)/conf
 	cp -r lib/GRNOC/Simp/Poller* dist/simp-poller-$(VERSION)/lib/GRNOC/Simp
+	cp -r lib/GRNOC/Simp/Poller/Config.pm dist/poller-config-$(VERSION)/lib/GRNOC/Simp/Poller
 	cp -r lib/GRNOC/Simp/Data* dist/simp-data-$(VERSION)/lib/GRNOC/Simp
 	cp -r lib/GRNOC/Simp/Comp* dist/simp-comp-$(VERSION)/lib/GRNOC/Simp
 	cp -r lib/GRNOC/Simp/TSDS* dist/simp-tsds-$(VERSION)/lib/GRNOC/Simp
@@ -57,9 +60,11 @@ dist:
 	cp -r simp-data.spec dist/simp-data-$(VERSION)/
 	cp -r simp-comp.spec dist/simp-comp-$(VERSION)/
 	cp -r simp-poller.spec dist/simp-poller-$(VERSION)/
+	cp -r perl-GRNOC-Simp-Poller-Config.spec dist/poller-config-$(VERSION)/
 	cp -r simp-tsds.spec dist/simp-tsds-$(VERSION)/
 	cp -r conf/sysconfig dist/simp-tsds-$(VERSION)/conf/
 	cd dist; tar -czvf simp-poller-$(VERSION).tar.gz simp-poller-$(VERSION)/ --exclude .svn --exclude .git
+	cd dist; tar -czvf poller-config-$(VERSION).tar.gz poller-config-$(VERSION)/ --exclude .svn --exclude .git
 	cd dist; tar -czvf simp-data-$(VERSION).tar.gz simp-data-$(VERSION)/ --exclude .svn --exclude .git
 	cd dist; tar -czvf simp-comp-$(VERSION).tar.gz simp-comp-$(VERSION)/ --exclude .svn --exclude .git
 	cd dist; tar -czvf simp-tsds-$(VERSION).tar.gz simp-tsds-$(VERSION)/ --exclude .svn --exclude .git

--- a/bin/compTestClient.pl
+++ b/bin/compTestClient.pl
@@ -8,12 +8,12 @@ use GRNOC::Log;
 use AnyEvent;
 
 my $client = GRNOC::RabbitMQ::Client->new(   host => "127.0.0.1",
-					     port => 5672,
-					     user => "guest", 
-					     pass => "guest",
-					     exchange => 'Simp',
-					     timeout => 15,
-					     topic => 'Simp.CompData');
+                                             port => 5672,
+                                             user => "guest",
+                                             pass => "guest",
+                                             exchange => 'Simp',
+                                             timeout => 15,
+                                             topic => 'Simp.CompData');
 
 my $results;
 
@@ -33,7 +33,7 @@ my $results;
    #$client->interfaceGbps(ipaddrs => '156.56.6.103');
 #}
 
-#warn Dumper($client->CPU(ipaddrs => '156.56.6.103')); 
+#warn Dumper($client->CPU(ipaddrs => '156.56.6.103'));
 #warn Dumper($client->Temp(ipaddrs => '156.56.6.103'));
 while(1){
   my $start = time;
@@ -48,8 +48,8 @@ while(1){
   my $et = $end - $start;
 
   if ($et == 0){
-	warn "huh\n";
-	next;
+        warn "huh\n";
+        next;
   }
   my $rate = $x / ($et * 1.0);
 

--- a/bin/genTestData.pl
+++ b/bin/genTestData.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl 
+#!/usr/bin/perl
 #--- script that will put a bunch of fake data into redis so we can create a bit of work for redis
 use strict;
 use Data::Dumper;
@@ -18,15 +18,15 @@ sub genHash{
     print "inserting data for host: $host\n";
     for(my $x=0;$x<50;$x++){
       for(my $y=0;$y<50;$y++){
-	my $oid  = $oid_str.$x.".".$y;
-	my $val  = $y;
-	#print "$oid -> $host : $val\n";
+        my $oid  = $oid_str.$x.".".$y;
+        my $val  = $y;
+        #print "$oid -> $host : $val\n";
          $redis->hset($oid,$host,$val,sub {});
       }
     }
     my $ts = gmtime();
     $redis->hset("ts",$host,$ts);
-    #$redis->wait_all_responses; 
+    #$redis->wait_all_responses;
   }
 }
 

--- a/bin/simp-comp.pl
+++ b/bin/simp-comp.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -I ../lib 
+#!/usr/bin/perl -I ../lib
 use strict;
 use warnings;
 
@@ -37,11 +37,11 @@ usage() if $help;
 
 
 my $data_services = GRNOC::Simp::CompData->new(
-			config_file    => $config_file,
+                        config_file    => $config_file,
                         logging_file   => $logging,
                         run_user       => $username,
                         run_group      => $groupname,
-			daemonize      => !$nofork );
+                        daemonize      => !$nofork );
 
 $data_services->start();
 

--- a/bin/simp-data.pl
+++ b/bin/simp-data.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -I ../lib 
+#!/usr/bin/perl -I ../lib
 use strict;
 use warnings;
 
@@ -37,11 +37,11 @@ usage() if $help;
 
 
 my $data_services = GRNOC::Simp::Data->new(
-			config_file    => $config_file,
+                        config_file    => $config_file,
                         logging_file   => $logging,
                         run_user       => $username,
                         run_group      => $groupname,
-			daemonize      => !$nofork );
+                        daemonize      => !$nofork );
 
 $data_services->start();
 

--- a/bin/simp-poller.pl
+++ b/bin/simp-poller.pl
@@ -1,8 +1,8 @@
-#!/usr/bin/perl -I ../lib 
+#!/usr/bin/perl -I ../lib
 #--- SNMP data collector
 #---   config file is used to define which parts of mib tree to collect
 #---   the set of hosts do poll and how many processes to use to do so.
-#---   nodes are divided up amongst processes in simple 1 in N fashion. 
+#---   nodes are divided up amongst processes in simple 1 in N fashion.
 use strict;
 use warnings;
 
@@ -34,11 +34,11 @@ my $groupname;
 
 GetOptions( 'config=s'  => \$config_file,
             'hosts=s'   => \$hosts_file,
- 	    'logging=s' => \$logging,
-	    'nofork'    => \$nofork,
-	    'user=s'    => \$username,
-	    'group=s'   => \$groupname,
-            'help|h|?'  => \$help ) 
+            'logging=s' => \$logging,
+            'nofork'    => \$nofork,
+            'user=s'    => \$username,
+            'group=s'   => \$groupname,
+            'help|h|?'  => \$help )
 
 or usage();
 
@@ -46,12 +46,12 @@ usage() if $help;
 
 
 my $poller = GRNOC::Simp::Poller->new(
-			config_file    => $config_file,
+                        config_file    => $config_file,
                         hosts_file     => $hosts_file,
                         logging_file   => $logging,
                         run_user       => $username,
                         run_group      => $groupname,
-			daemonize      => !$nofork );
+                        daemonize      => !$nofork );
 
 $poller->start();
 

--- a/bin/simp-tsds.pl
+++ b/bin/simp-tsds.pl
@@ -30,7 +30,7 @@ GetOptions(
     'help|h|?' => \$help,
 );
 
-usage() if ($help); 
+usage() if ($help);
 
 Log::Log4perl::init($logging_file);
 

--- a/bin/testClient.pl
+++ b/bin/testClient.pl
@@ -7,12 +7,12 @@ use GRNOC::RabbitMQ::Client;
 use AnyEvent;
 
 my $client = GRNOC::RabbitMQ::Client->new(   host => "127.0.0.1",
-					     port => 5672,
-					     user => "guest", 
-					     pass => "guest",
-					     exchange => 'Simp',
-					     timeout => 1,
-					     topic => 'Simp.Data');
+                                             port => 5672,
+                                             user => "guest",
+                                             pass => "guest",
+                                             exchange => 'Simp',
+                                             timeout => 1,
+                                             topic => 'Simp.Data');
 my $results;
 my $start;
 my $sum = 0;

--- a/lib/GRNOC/Simp/CompData.pm
+++ b/lib/GRNOC/Simp/CompData.pm
@@ -177,11 +177,11 @@ sub start {
 
         $self->logger->debug( 'Running in foreground.' );
 
-        #-- when in fg just act as a working directly with no sub processes so we can nytprof 
+        #-- when in fg just act as a working directly with no sub processes so we can nytprof
         my $worker = GRNOC::Simp::CompData::Worker->new( config    => $self->config,
-						     logger    => $self->logger,
-						     worker_id => 13 );
-	
+                                                     logger    => $self->logger,
+                                                     worker_id => 13 );
+
         # this should only return if we tell it to stop via TERM signal etc.
         $worker->start();
     }
@@ -235,19 +235,19 @@ sub _create_workers {
                            } );
     # create high res workers
     for (my $worker_id=0; $worker_id<$workers;$worker_id++) {
-        
+
         $forker->start() and next;
 
 
-	# create worker in this process
-	my $worker = GRNOC::Simp::CompData::Worker->new( config    => $self->config,
-						     logger    => $self->logger,
-						     worker_id => $worker_id );
-	
-	# this should only return if we tell it to stop via TERM signal etc.
-	$worker->start();
-	
-	# exit child process
+        # create worker in this process
+        my $worker = GRNOC::Simp::CompData::Worker->new( config    => $self->config,
+                                                     logger    => $self->logger,
+                                                     worker_id => $worker_id );
+
+        # this should only return if we tell it to stop via TERM signal etc.
+        $worker->start();
+
+        # exit child process
         $forker->finish();
     }
 

--- a/lib/GRNOC/Simp/CompData/Worker.pm
+++ b/lib/GRNOC/Simp/CompData/Worker.pm
@@ -93,7 +93,7 @@ sub start {
 
   while(1){
     #--- we use try catch to, react to issues such as com failure
-    #--- when any error condition is found, the reactor stops and we then reinitialize 
+    #--- when any error condition is found, the reactor stops and we then reinitialize
     $self->logger->debug( $self->worker_id." restarting." );
     $self->_start();
     exit(0) if $self->do_shutdown;
@@ -130,7 +130,7 @@ sub _start {
     my $rabbit_port = $self->config->get( '/config/rabbitMQ/@port' );
     my $rabbit_user = $self->config->get( '/config/rabbitMQ/@user' );
     my $rabbit_pass = $self->config->get( '/config/rabbitMQ/@password' );
- 
+
     $self->logger->debug( 'Setup RabbitMQ' );
 
     my $client = GRNOC::RabbitMQ::Client->new(  host => $rabbit_host,
@@ -143,16 +143,16 @@ sub _start {
 
     $self->_set_client($client);
 
-    my $dispatcher = GRNOC::RabbitMQ::Dispatcher->new( 	queue_name => "Simp.CompData",
-							topic => "Simp.CompData",
-							exchange => "Simp",
-							user => $rabbit_user,
-							pass => $rabbit_pass,
-							host => $rabbit_host,
-							port => $rabbit_port);
+    my $dispatcher = GRNOC::RabbitMQ::Dispatcher->new(  queue_name => "Simp.CompData",
+                                                        topic => "Simp.CompData",
+                                                        exchange => "Simp",
+                                                        user => $rabbit_user,
+                                                        pass => $rabbit_pass,
+                                                        host => $rabbit_host,
+                                                        port => $rabbit_port);
 
     #--- parse config and create methods based on the set of composite definitions.
-    $self->config->{'force_array'} = 1; 
+    $self->config->{'force_array'} = 1;
     my $allowed_methods = $self->config->get( '/config/composite' );
 
     foreach my $meth (@$allowed_methods){
@@ -160,21 +160,21 @@ sub _start {
       print "$method_id:\n";
 
       my $method = GRNOC::RabbitMQ::Method->new(  name => "$method_id",
-						  async => 1,
+                                                  async => 1,
                                                   callback =>  sub {$self->_get($method_id,@_) },
                                                   description => "retrieve composite simp data of type $method_id, we should add a descr to the config");
 
       $method->add_input_parameter( name => 'node',
-				    description => 'nodes to retrieve data for',
-				    required => 1,
-				    multiple => 1,
-				    pattern => $GRNOC::WebService::Regex::TEXT);
+                                    description => 'nodes to retrieve data for',
+                                    required => 1,
+                                    multiple => 1,
+                                    pattern => $GRNOC::WebService::Regex::TEXT);
 
       $method->add_input_parameter( name => 'period',
-				    description => "period of time to request for the data!",
-				    required => 0,
-				    multiple => 0,
-				    pattern => $GRNOC::WebService::Regex::ANY_NUMBER);
+                                    description => "period of time to request for the data!",
+                                    required => 0,
+                                    multiple => 0,
+                                    pattern => $GRNOC::WebService::Regex::ANY_NUMBER);
 
       #--- let xpath do the iteration for us
       my $path = "/config/composite[\@id=\"$method_id\"]/input";
@@ -186,11 +186,11 @@ sub _start {
         if(defined $input->{'required'}){$required = 1;}
 
         $method->add_input_parameter( name => $input_id,
-				      description => "we will add description to the config file later",
-				      required => $required,
-				      multiple => 1,
-				      pattern => $GRNOC::WebService::Regex::TEXT);
-        
+                                      description => "we will add description to the config file later",
+                                      required => $required,
+                                      multiple => 1,
+                                      pattern => $GRNOC::WebService::Regex::TEXT);
+
 
         print "  $input_id: $required:\n";
       }
@@ -206,12 +206,12 @@ sub _start {
                                                 description => "function to test latency");
 
     $dispatcher->register_method($method2);
- 
+
     $self->_set_rmq_dispatcher( $dispatcher );
-    #--- go into event loop handing requests that come in over rabbit  
+    #--- go into event loop handing requests that come in over rabbit
     $self->logger->debug( 'Entering RabbitMQ event loop' );
     $dispatcher->start_consuming();
-    
+
     #--- you end up here if one of the handlers called stop_consuming
     $self->_set_rmq_dispatcher( undef );
     return;
@@ -288,12 +288,12 @@ sub _get{
   $cv[1]->begin(sub { $self->_do_vals($ref, $params, \%results, $cv[2]); });
   $cv[2]->begin(sub { $self->_do_functions($ref, $params, \%results, $cv[3]); });
   $cv[3]->begin(sub { &$success_callback($results{'final'});
-		      undef %results;
-		      undef $ref;
-		      undef $params;
-		      undef @cv;
-		      undef $success_callback;
-		});
+                      undef %results;
+                      undef $ref;
+                      undef $params;
+                      undef @cv;
+                      undef $success_callback;
+                });
 
   # Start off the pipeline:
   $cv[0]->end;
@@ -309,10 +309,10 @@ sub _do_scans{
 
   #--- find the set of required variables
   my $hosts = $params->{'node'}{'value'};
-  
+
   #--- this function will execute multiple scans in "parallel" using the begin / end approach
   #--- we use $cv to signal when all those scans are done
-  
+
   #--- give up on config object and go direct to xmllib to get proper xpath support
   #--- these should be moved to the constructor
   my $doc = $self->config->{'doc'};
@@ -325,7 +325,7 @@ sub _do_scans{
       $results->{'val'}{$host} = {};
       $results->{'hostvar'}{$host} = {};
   }
- 
+
   foreach my $instance ($xrefs->get_nodelist){
       my $instance_id = $instance->getAttribute("id");
       #--- get the list of scans to perform
@@ -333,23 +333,23 @@ sub _do_scans{
       foreach my $scan ($scanres->get_nodelist){
           # example scan:
           # <scan id="ifIdx" oid="1.3.6.1.2.1.31.1.1.1.18.*" var="ifAlias" />
-	  my $var_name = $scan->getAttribute("id");
-	  my $oid      = $scan->getAttribute("oid");
-	  my $param_nm = $scan->getAttribute("var");
-	  my $targets;
-	  if(defined($param_nm) && defined($params->{$param_nm})){
-	      $targets = $params->{$param_nm}{"value"};
-	  }
-	  $cv->begin;
+          my $var_name = $scan->getAttribute("id");
+          my $oid      = $scan->getAttribute("oid");
+          my $param_nm = $scan->getAttribute("var");
+          my $targets;
+          if(defined($param_nm) && defined($params->{$param_nm})){
+              $targets = $params->{$param_nm}{"value"};
+          }
+          $cv->begin;
 
-	  $self->client->get(
-	      node => $hosts, 
-	      oidmatch => $oid,
-	      async_callback => sub {
-		  my $data = shift;
-		  $self->_scan_cb($data->{'results'},$hosts,$var_name,$oid,$targets,$results); 
-		  $cv->end;
-	      } );
+          $self->client->get(
+              node => $hosts,
+              oidmatch => $oid,
+              async_callback => sub {
+                  my $data = shift;
+                  $self->_scan_cb($data->{'results'},$hosts,$var_name,$oid,$targets,$results);
+                  $cv->end;
+              } );
       }
   }
   $cv->end;
@@ -366,7 +366,7 @@ sub _scan_cb{
 
   $oid_pattern =~ s/\*.*$//;
   $oid_pattern =  quotemeta($oid_pattern);
-  
+
   foreach my $host (@$hosts){
 
       my @oid_suffixes;
@@ -375,10 +375,10 @@ sub _scan_cb{
       my $use_val_matches = (defined($vals) && (scalar(@$vals) > 0));
 
       foreach my $oid (keys %{$data->{$host}}){
-	  my $base_value = $data->{$host}{$oid}{'value'};
+          my $base_value = $data->{$host}{$oid}{'value'};
 
           # strip out the wildcard part of the oid
-	  $oid =~ s/^$oid_pattern//;
+          $oid =~ s/^$oid_pattern//;
 
           if((!$use_val_matches) || (any { $base_value =~ /$_/ } @$vals)){
               push @oid_suffixes, $oid;
@@ -388,7 +388,7 @@ sub _scan_cb{
 
       $results->{'scan'}{$host}{$var_name} = \@oid_suffixes;
   }
-  
+
   return ;
 }
 
@@ -399,10 +399,10 @@ sub _do_vals{
     my $params       = shift; # parameters to request
     my $results      = shift; # request-global $results hash
     my $cv           = shift; # assumes that it's been begin()'ed with a callback
-    
+
     #--- find the set of required variables
     my $hosts = $params->{'node'}{'value'};
-    
+
     #--- this function will execute multiple gets in "parallel" using the begin / end apprach
     #--- we use $cv to signal when all those gets are done
 
@@ -422,11 +422,11 @@ sub _do_vals{
     #--- these should be moved to the constructor
     my $doc = $self->config->{'doc'};
     my $xpc = XML::LibXML::XPathContext->new($doc);
-    
+
     foreach my $instance ($xrefs->get_nodelist){
-	#--- get the list of scans to perform
-	my $valres = $xpc->find("./result/val",$instance);
-	foreach my $val ($valres->get_nodelist){
+        #--- get the list of scans to perform
+        my $valres = $xpc->find("./result/val",$instance);
+        foreach my $val ($valres->get_nodelist){
             # The <val> tag can have a couple of different forms:
             #
             # <val id="var_name" var="scan_var_name">
@@ -434,16 +434,16 @@ sub _do_vals{
             # <val id="var_name" type="rate" oid="1.2.3.4.scan_var_name">
             #     - use OID suffixes from the scan phase, and lookup other OIDs,
             #       optionally doing a rate calculation
-	    my $id      = $val->getAttribute("id");
-	    my $var     = $val->getAttribute("var");
-	    my $oid     = $val->getAttribute("oid");
-	    my $type    = $val->getAttribute("type");
-	    
-	    if(!defined $id){
-		#--- required data missing
+            my $id      = $val->getAttribute("id");
+            my $var     = $val->getAttribute("var");
+            my $oid     = $val->getAttribute("oid");
+            my $type    = $val->getAttribute("type");
+
+            if(!defined $id){
+                #--- required data missing
                 $self->logger->error('no ID specified in a <val> element');
-		next;
-	    }
+                next;
+            }
 
             if(!defined $oid){ # Use the results of a scan
                 if(!defined $var){
@@ -521,8 +521,8 @@ sub _do_vals{
                             oidmatch => [$oid_base],
                             async_callback => sub {
                                 my $data = shift;
-				$self->_val_cb($data->{'results'},$results,$host,\%lut);
-				$cv->end;
+                                $self->_val_cb($data->{'results'},$results,$host,\%lut);
+                                $cv->end;
                             }
                         );
                     }else{
@@ -531,16 +531,16 @@ sub _do_vals{
                             oidmatch => [$oid_base],
                             async_callback => sub {
                                 my $data = shift;
-				$self->_val_cb($data->{'results'},$results,$host,\%lut);
-				$cv->end;
+                                $self->_val_cb($data->{'results'},$results,$host,\%lut);
+                                $cv->end;
                             }
                         );
                     }
                 }
             }
-	}
+        }
     }
-    $cv->end; 
+    $cv->end;
 }
 
 sub _hostvar_cb{

--- a/lib/GRNOC/Simp/Data.pm
+++ b/lib/GRNOC/Simp/Data.pm
@@ -178,11 +178,11 @@ sub start {
 
         $self->logger->debug( 'Running in foreground.' );
 
-        #-- when in fg just act as a working directly with no sub processes so we can nytprof 
+        #-- when in fg just act as a working directly with no sub processes so we can nytprof
         my $worker = GRNOC::Simp::Data::Worker->new( config    => $self->config,
-						     logger    => $self->logger,
-						     worker_id => 13 );
-	
+                                                     logger    => $self->logger,
+                                                     worker_id => 13 );
+
         # this should only return if we tell it to stop via TERM signal etc.
         $worker->start();
     }
@@ -236,19 +236,19 @@ sub _create_workers {
                            } );
     # create high res workers
     for (my $worker_id=0; $worker_id<$workers;$worker_id++) {
-        
+
         $forker->start() and next;
 
 
-	# create worker in this process
-	my $worker = GRNOC::Simp::Data::Worker->new( config    => $self->config,
-						     logger    => $self->logger,
-						     worker_id => $worker_id );
-	
-	# this should only return if we tell it to stop via TERM signal etc.
-	$worker->start();
-	
-	# exit child process
+        # create worker in this process
+        my $worker = GRNOC::Simp::Data::Worker->new( config    => $self->config,
+                                                     logger    => $self->logger,
+                                                     worker_id => $worker_id );
+
+        # this should only return if we tell it to stop via TERM signal etc.
+        $worker->start();
+
+        # exit child process
         $forker->finish();
     }
 

--- a/lib/GRNOC/Simp/Data/Worker.pm
+++ b/lib/GRNOC/Simp/Data/Worker.pm
@@ -439,7 +439,8 @@ sub _get{
                 foreach my $set (@$sets){
                     next if !defined($set);
 
-                    my ($host, $group, $time) = split(',',$set);
+                    my @components = split(',',$set);
+                    my $time = $components[-1];
 
                     my $keys;
                     my $cursor = 0;

--- a/lib/GRNOC/Simp/Poller.pm
+++ b/lib/GRNOC/Simp/Poller.pm
@@ -317,7 +317,7 @@ sub _create_workers {
                                                          max_reps      => $max_reps,
                                                          snmp_timeout  => $snmp_timeout,
                                                          var_hosts     => $varsByWorker{$worker_name},
-                                                         monitoring_retention => $group{'monitoring_retention'},
+                                                         monitoring_retention => $group->{'monitoring_retention'},
               );
 
         # this should only return if we tell it to stop via TERM signal etc.

--- a/lib/GRNOC/Simp/Poller.pm
+++ b/lib/GRNOC/Simp/Poller.pm
@@ -263,7 +263,7 @@ sub _create_workers {
       my $idx = 0;
 
       #--- get the set of hosts that belong to this group
-      my $hosts = $self->config->{'group'}{$name};
+      my $hosts = $self->config->{'host_groups'}{$name};
       my @hosts;
       @hosts = @$hosts if defined($hosts);
 

--- a/lib/GRNOC/Simp/Poller.pm
+++ b/lib/GRNOC/Simp/Poller.pm
@@ -316,7 +316,8 @@ sub _create_workers {
                                                          logger        => $self->logger,
                                                          max_reps      => $max_reps,
                                                          snmp_timeout  => $snmp_timeout,
-                                                         var_hosts     => $varsByWorker{$worker_name}
+                                                         var_hosts     => $varsByWorker{$worker_name},
+                                                         monitoring_retention => $group{'monitoring_retention'},
               );
 
         # this should only return if we tell it to stop via TERM signal etc.

--- a/lib/GRNOC/Simp/Poller.pm
+++ b/lib/GRNOC/Simp/Poller.pm
@@ -239,7 +239,7 @@ sub _create_workers {
     # This hash keeps track of whether a host has had a worker assigned for that.
     my %var_worker;
 
-    my $total_workers = sum { scalar @{$groups{$_}{'workers'}} } (keys %groups);
+    my $total_workers = sum ( map { scalar @{$groups{$_}{'workers'}} } (keys %groups) );
 
     my $forker = Parallel::ForkManager->new( $total_workers + 2);
 

--- a/lib/GRNOC/Simp/Poller.pm
+++ b/lib/GRNOC/Simp/Poller.pm
@@ -301,7 +301,7 @@ sub _create_workers {
 
       #--- get the set of OIDS for this group
       my @oids;
-      foreach my$line(@{$group->{'mib'}}){
+      foreach my $line (@{$group->{'mib'}}){
 	push(@oids,$line->{'oid'});
       }
 

--- a/lib/GRNOC/Simp/Poller.pm
+++ b/lib/GRNOC/Simp/Poller.pm
@@ -5,17 +5,18 @@ use warnings;
 use Data::Dumper;
 use Moo;
 use Types::Standard qw( Str Bool );
+use List::Util qw( sum );
 
 use Parallel::ForkManager;
 use Proc::Daemon;
 use POSIX qw( setuid setgid );
 
-use GRNOC::Config;
 use GRNOC::Log;
 
 our $VERSION = '1.0.6';
 
 use GRNOC::Simp::Poller::Worker;
+use GRNOC::Simp::Poller::Config;
 
 ### required attributes ###
 
@@ -71,8 +72,6 @@ has run_group => ( is => 'ro',
 
 =item config
 
-=item hosts
-
 =item logger
 
 =item children
@@ -82,8 +81,6 @@ has run_group => ( is => 'ro',
 =cut
 
 has config => ( is => 'rwp' );
-
-has hosts  => ( is => 'rwp' );
 
 has logger => ( is => 'rwp' );
 
@@ -104,46 +101,14 @@ sub BUILD {
 
     $self->_set_logger( $logger );
 
-    # create and store config objects
-    my $config = GRNOC::Config->new( config_file => $self->config_file,
-                                     force_array => 1 );
+    my $config = GRNOC::Simp::Poller::Config::build_config(
+        config_file => $self->config_file,
+        hosts_dir   => $self->hosts_file,
+    );
+
     $self->_set_config( $config );
 
-    $self->_process_hosts_config();
-
     return $self;
-}
-
-=head2 _process_hosts_config
-
-=cut
-
-sub _process_hosts_config{
-    my $self = shift;
-
-    opendir my $dir, $self->hosts_file;
-    my @files = readdir $dir;
-    closedir $dir;
-
-    my @hosts;
-
-    foreach my $file (@files){
-
-        next if $file !~ /\.xml$/; # so we don't ingest editor tempfiles, etc.
-
-        my $conf = GRNOC::Config->new( config_file => $self->hosts_file . "/" . $file,
-                                       force_array => 1);
-
-
-        my $rawhosts = $conf->get("/config/host");
-        foreach my $raw (@$rawhosts){
-            push(@hosts, $raw);
-        }
-    }
-
-    $self->_set_hosts(\@hosts);
-
-
 }
 
 =head2 start
@@ -180,10 +145,7 @@ sub start {
 
         $self->logger->debug( 'Daemonizing.' );
 
-        my $pid_file = $self->config->get( '/config/@pid-file' )->[0];
-        if(!defined($pid_file)){
-            $pid_file = "/var/run/simp_poller.pid";
-        }
+        my $pid_file = $self->config->{'global'}{'pid_file'};
 
         $self->logger->debug("PID FILE: " . $pid_file);
         my $daemon = Proc::Daemon->new( pid_file => $pid_file );
@@ -270,29 +232,23 @@ sub _create_workers {
 
     my ( $self ) = @_;
 
-   #--- get the set of active groups
-    my $groups  = $self->config->get( "/config/group" );
+    #--- get the set of active groups
+    my %groups = %{$self->config->{'groups'}};
 
     # For each host, one worker handles the host variables.
     # This hash keeps track of whether a host has had a worker assigned for that.
     my %var_worker;
 
-    my $total_workers = 0;
-    foreach my $group (@$groups){
-        #--- ignore the group if it isnt active
-        next if($group->{'active'} == 0);
-        $total_workers += $group->{'workers'};
-    }
+    my $total_workers = sum { scalar @{$groups{$_}{'workers'}} } (keys %groups);
 
     my $forker = Parallel::ForkManager->new( $total_workers + 2);
 
-    #--- create workers for each group
-    foreach my $group (@$groups){
-      #--- ignore the group if it isnt active
-      next if($group->{'active'} == 0);
+    #--- create workers for each active group
+    foreach my $group (values %groups){
 
       my $name    = $group->{"name"};
-      my $workers = $group->{'workers'};
+      my @worker_names = @{$group->{'workers'}};
+      my $num_workers  = scalar(@worker_names);
 
       my $poll_interval = $group->{'interval'};
       my $retention     = $group->{'retention'};
@@ -300,43 +256,29 @@ sub _create_workers {
       my $max_reps      = $group->{'max_reps'};
 
       #--- get the set of OIDS for this group
-      my @oids;
-      foreach my $line (@{$group->{'mib'}}){
-        push(@oids,$line->{'oid'});
-      }
+      my @oids = @{$group->{'mib'}};
 
-      my %hostsByWorker;
-      my %varsByWorker;
-      my $idx=0;
+      my %hostsByWorker = map { $_ => [] } @worker_names;
+      my %varsByWorker  = map { $_ => {} } @worker_names;
+      my $idx = 0;
+
       #--- get the set of hosts that belong to this group
-      my $id= $group->{'name'};
-
+      my $hosts = $self->config->{'group'}{$name};
       my @hosts;
-
-      foreach my $host (@{$self->hosts}){
-          my $groups = $host->{'group'};
-          foreach my $group (keys %$groups){
-              if($group eq $id){
-                  #-- match add the host to the host list
-                  push(@hosts,$host);
-                  # no double-pushing:
-                  last;
-              }
-          }
-      }
+      @hosts = @$hosts if defined($hosts);
 
       #--- split hosts between workers
       foreach my $host (@hosts){
-        push(@{$hostsByWorker{$idx}},$host);
+        push(@{$hostsByWorker{$worker_names[$idx]}},$host);
         if(!$var_worker{$host->{'node_name'}}){
             $var_worker{$host->{'node_name'}} = 1;
-            $varsByWorker{$idx}{$host->{'node_name'}} = 1;
+            $varsByWorker{$worker_names[$idx]}{$host->{'node_name'}} = 1;
         }
         $idx++;
-        if($idx>=$workers) { $idx = 0; }
+        if($idx>=$num_workers) { $idx = 0; }
       }
 
-      $self->logger->info( "Creating $workers child processes for group: $name" );
+      $self->logger->info( "Creating $num_workers child processes for group: $name" );
 
       # keep track of children pids
       $forker->run_on_start( sub {
@@ -360,21 +302,21 @@ sub _create_workers {
 
 
       # create workers
-      for (my $worker_id=0; $worker_id<$workers;$worker_id++) {
+      foreach my $worker_name (@worker_names) {
           $forker->start() and next;
 
           # create worker in this process
-          my $worker = GRNOC::Simp::Poller::Worker->new( instance      => $worker_id,
+          my $worker = GRNOC::Simp::Poller::Worker->new( worker_name   => $worker_name,
                                                          group_name    => $name,
-                                                         config        => $self->config,
+                                                         global_config => $self->config->{'global'},
                                                          oids          => \@oids,
-                                                         hosts       => $hostsByWorker{$worker_id},
+                                                         hosts         => $hostsByWorker{$worker_name},
                                                          poll_interval => $poll_interval,
                                                          retention     => $retention,
                                                          logger        => $self->logger,
                                                          max_reps      => $max_reps,
                                                          snmp_timeout  => $snmp_timeout,
-                                                         var_hosts     => $varsByWorker{$worker_id} || {}
+                                                         var_hosts     => $varsByWorker{$worker_name}
               );
 
         # this should only return if we tell it to stop via TERM signal etc.

--- a/lib/GRNOC/Simp/Poller/Config.pm
+++ b/lib/GRNOC/Simp/Poller/Config.pm
@@ -2,6 +2,19 @@ package GRNOC::Simp::Poller::Config;
 
 use GRNOC::Config;
 
+=head1 Methods
+
+=over 12
+
+=cut
+
+=item build_config
+
+Parses a simp-poller config file and hosts.d dir, and returns objects
+representing the config files.
+
+=cut
+
 sub build_config {
     my %args = @_;
 

--- a/lib/GRNOC/Simp/Poller/Config.pm
+++ b/lib/GRNOC/Simp/Poller/Config.pm
@@ -52,7 +52,7 @@ sub build_config {
         my $num_workers = int(0 + $group->{'workers'});
         $num_workers = 1 if $num_workers < 1;
         for (my $i = 0; $i < $num_workers; $i++) {
-            push @workers, "$grp{'name'}$i";
+            push @workers, "$grp{'name'},$i";
         }
         $grp{'workers'} = \@workers;
 

--- a/lib/GRNOC/Simp/Poller/Config.pm
+++ b/lib/GRNOC/Simp/Poller/Config.pm
@@ -2,6 +2,8 @@ package GRNOC::Simp::Poller::Config;
 
 use GRNOC::Config;
 
+use constant DEFAULT_MONITORING_RETENTION => 20;
+
 =head1 Methods
 
 =over 12
@@ -61,6 +63,11 @@ sub build_config {
         foreach my $i ('name', 'interval', 'snmp_timeout', 'max_reps', 'retention') {
             $grp{$i} = $group->{$i};
         }
+
+        my $mon_retention = $group->{'monitoring_retention_cycles'};
+        $mon_retention = DEFAULT_MONITORING_RETENTION if !defined($mon_retention);
+        $mon_retention = 1 if (0 + $mon_retention) < 1;
+        $grp{'monitoring_retention'} = 0 + $mon_retention;
 
         my @workers;
         my $num_workers = int(0 + $group->{'workers'});

--- a/lib/GRNOC/Simp/Poller/Config.pm
+++ b/lib/GRNOC/Simp/Poller/Config.pm
@@ -23,6 +23,11 @@ sub build_config {
     my $conf_file = $args{'config_file'};
     my $hosts_dir = $args{'hosts_dir'};
 
+    die 'argument config_file not defined!' if !defined($conf_file);
+    die 'argument hosts_dir not defined!'   if !defined($hosts_dir);
+    die "Config file '$conf_file' not a regular file!"  if ! -f $conf_file;
+    die "Hosts directory '$hosts_dir' not a directory!" if ! -d $hosts_dir;
+
 
     # Config that isn't specific to a group or a host: { redis_host, redis_port, pid_file }
     my %globals;

--- a/lib/GRNOC/Simp/Poller/Config.pm
+++ b/lib/GRNOC/Simp/Poller/Config.pm
@@ -90,7 +90,7 @@ sub build_config {
             $host{'host_variable'} = {};
 
             foreach my $var (keys %{$raw->{'host_variable'} || {}}) {
-                $host{'host_variable'}{$var} = $raw->{'host_variable'}{'value'};
+                $host{'host_variable'}{$var} = $raw->{'host_variable'}{$var}{'value'};
             }
 
             $host{'groups'} = {};

--- a/lib/GRNOC/Simp/Poller/Worker.pm
+++ b/lib/GRNOC/Simp/Poller/Worker.pm
@@ -535,7 +535,7 @@ sub _write_host_status {
     } catch {
         $self->logger->error($self->worker_name . " unable to write monitoring status for ($host_group) to Redis");
         $redis->select(DB_MAIN);
-    }
+    };
 
     $host->{'poll_status'} = undef;
 }
@@ -554,7 +554,7 @@ sub _write_heartbeat {
     } catch {
         $self->logger->error($self->worker_name . ' unable to write heartbeat to Redis');
         $redis->select(DB_MAIN);
-    }
+    };
 }
 
 1;

--- a/lib/GRNOC/Simp/Poller/Worker.pm
+++ b/lib/GRNOC/Simp/Poller/Worker.pm
@@ -320,7 +320,7 @@ sub _poll_cb{
     } catch {
         $redis->select(DB_MAIN);
         $self->logger->error($self->worker_name. " $id Error in hset for data: $_" );
-    }
+    };
 
     if(scalar(keys %{$host->{'pending_replies'}}) == 0){
         $self->_write_host_status($host, $timestamp);
@@ -355,7 +355,7 @@ sub _connect_to_snmp{
             $self->{'snmp'}{$host->{'node_name'}} = $snmp;
 
         }elsif($host->{'snmp_version'} eq '3'){
-            if(scalar($host->{'groups'}{$self->group_name}) == 0){
+            if(scalar(@{$host->{'groups'}{$self->group_name}}) == 0){
                 ($snmp, $error) = Net::SNMP->session(
                     -hostname         => $host->{'ip'},
                     -version          => '3',
@@ -462,7 +462,7 @@ sub _collect_data{
                     );
             }else{
                 #for each context engine specified for the group
-                if(scalar($host->{'groups'}{$self->group_name}) == 0){
+                if(scalar(@{$host->{'groups'}{$self->group_name}}) == 0){
                     $host->{'pending_replies'}->{$oid} = 1;
                     $res = $self->{'snmp'}{$host->{'node_name'}}->get_table(
                         -baseoid      => $oid,
@@ -508,6 +508,7 @@ sub _write_host_status {
     my $host = shift;
     my $timestamp = shift;
 
+    my $redis = $self->redis;
     my $host_group = $host->{'node_name'} . ',' . $self->group_name;
 
     my $monitoring_key = "simp-poller,host-status,$host_group";

--- a/lib/GRNOC/Simp/Poller/Worker.pm
+++ b/lib/GRNOC/Simp/Poller/Worker.pm
@@ -43,13 +43,13 @@ use constant N => 20;
 
 =cut
 has group_name => (is => 'ro',
-		   required => 1);
+                   required => 1);
 
 has instance => (is => 'ro',
-		 required => 1);
+                 required => 1);
 
 has config      => ( is => 'ro',
-		     required => 1 );
+                     required => 1 );
 
 
 has logger => ( is => 'rwp',
@@ -59,10 +59,10 @@ has hosts => ( is => 'ro',
                required => 1 );
 
 has oids => ( is => 'ro',
-	      required => 1 );
+              required => 1 );
 
 has poll_interval => ( is => 'ro',
-		       required => 1 );
+                       required => 1 );
 
 has var_hosts => ( is => 'ro',
                    required => 1 );
@@ -94,25 +94,25 @@ has var_hosts => ( is => 'ro',
 =cut
 
 has worker_name => (is => 'rwp',
-		    required => 0,
-		    default => 'unknown');
+                    required => 0,
+                    default => 'unknown');
 
 has is_running => ( is => 'rwp',
                     default => 0 );
 
 has need_restart => (is => 'rwp',
-		     default => 0 );
+                     default => 0 );
 
 has redis => ( is => 'rwp' );
 
 has retention => (is => 'rwp',
-		  default => 5);
+                  default => 5);
 
 has max_reps => (is => 'rwp',
-		 default => 1);
+                 default => 1);
 
 has snmp_timeout => (is => 'rwp',
-		     default => 5);
+                     default => 5);
 
 has main_cv => (is => 'rwp');
 
@@ -129,9 +129,9 @@ has main_cv => (is => 'rwp');
 =cut
 
 sub start {
-    
+
     my ( $self ) = @_;
-    
+
     $self->_set_worker_name($self->group_name . $self->instance);
 
     my $logger = GRNOC::Log->get_logger($self->worker_name);
@@ -139,67 +139,67 @@ sub start {
 
     my $worker_name = $self->worker_name;
     $self->logger->error( $self->worker_name." Starting." );
-    
+
     # flag that we're running
     $self->_set_is_running( 1 );
-    
+
     # change our process name
     $0 = "simp($worker_name)";
 
     # setup signal handlers
     $SIG{'TERM'} = sub {
-	
+
         $self->logger->info($self->worker_name. " Received SIG TERM." );
         $self->stop();
     };
-    
+
     $SIG{'HUP'} = sub {
-	
+
         $self->logger->info($self->worker_name. " Received SIG HUP." );
     };
 
     # connect to redis
     my $redis_host = $self->config->get( '/config/redis/@host' )->[0];
     my $redis_port = $self->config->get( '/config/redis/@port' )->[0];
-    
+
     $self->logger->debug($self->worker_name." Connecting to Redis $redis_host:$redis_port." );
-    
+
     my $redis;
 
     try {
-	#--- try to connect twice per second for 30 seconds, 60 attempts every 500ms.
-	$redis = Redis->new(
-	    server    => "$redis_host:$redis_port",
-	    reconnect => 60,
-	    every     => 500,
-	    read_timeout => 2,
-	    write_timeout => 3,
-	    );
+        #--- try to connect twice per second for 30 seconds, 60 attempts every 500ms.
+        $redis = Redis->new(
+            server    => "$redis_host:$redis_port",
+            reconnect => 60,
+            every     => 500,
+            read_timeout => 2,
+            write_timeout => 3,
+            );
     }
     catch {
         $self->logger->error($self->worker_name." Error connecting to Redis: $_" );
     };
-    
+
     $self->_set_redis( $redis );
-    
+
     $self->_set_need_restart(0);
-    
+
     $self->logger->debug( $self->worker_name . ' Starting SNMP Poll loop.' );
-    
+
     $self->_connect_to_snmp();
 
     $self->logger->debug($self->worker_name . ' var_hosts: "' . (join '", "', (keys %{$self->var_hosts})) . '"');
 
     $self->{'collector_timer'} = AnyEvent->timer( after => 10,
-						  interval => $self->poll_interval,
-						  cb => sub {
+                                                  interval => $self->poll_interval,
+                                                  cb => sub {
                                                       my $cycle_cv = AnyEvent->condvar;
                                                       $cycle_cv->begin(sub { undef $cycle_cv; $self->_write_heartbeat(); });
                                                       $self->_collect_data($cycle_cv);
                                                       $cycle_cv->end;
-						      AnyEvent->now_update;
-						  });
-    
+                                                      AnyEvent->now_update;
+                                                  });
+
 
     #let the magic happen
     my $cv = AnyEvent->condvar;
@@ -246,88 +246,88 @@ sub _poll_cb{
     }
 
     if(!defined $data){
-	my $error = $session->error();
-	$self->logger->error("Host/Context ID: $host->{'node_name'} " . (defined($context_id) ? $context_id : '[no context ID]'));
-	$self->logger->error("$id failed     $reqstr");
-	$self->logger->error("Error: $error");
+        my $error = $session->error();
+        $self->logger->error("Host/Context ID: $host->{'node_name'} " . (defined($context_id) ? $context_id : '[no context ID]'));
+        $self->logger->error("$id failed     $reqstr");
+        $self->logger->error("Error: $error");
 
         $host->{'poll_status'} = 'TO';
         if (scalar(keys %{$host->{'pending_replies'}}) == 0){
             $self->_write_host_status($host, $timestamp);
             $cycle_cv->end;
         }
-	return;
+        return;
     }
 
     my @values;
 
     for my $oid (keys %$data){
-	push(@values, "$oid," .  $data->{$oid});
+        push(@values, "$oid," .  $data->{$oid});
     }
 
     my $expires = $timestamp + $self->retention;
 
     try {
 
-	$redis->select(DB_MAIN);
-	my $key = $host->{'node_name'} . "," . $self->worker_name . ",$timestamp";
-	$redis->sadd($key, @values);
-	
-	if(scalar(keys %{$host->{'pending_replies'}}) == 0){
-	    #$self->logger->error("Received all responses!");
-	    $redis->expireat($key, $expires);
-	    
-	    #our poll_id to time lookup
-	    $redis->select(DB_POLLID_TO_KEY);
-	    $redis->set($host->{'node_name'} . "," . $self->group_name . "," . $host->{'poll_id'}, $key);
-	    $redis->set($ip . "," . $self->group_name . "," . $host->{'poll_id'}, $key);
-	    #and expire
-	    $redis->expireat($host->{'node_name'} . "," . $self->group_name . "," . $host->{'poll_id'}, $expires);
-	    $redis->expireat($ip . "," . $self->group_name . "," . $host->{'poll_id'},$expires);
-	    
-            $redis->select(DB_MAIN);
-	    #$self->logger->error(Dumper($host->{'group'}{$self->group_name}));
+        $redis->select(DB_MAIN);
+        my $key = $host->{'node_name'} . "," . $self->worker_name . ",$timestamp";
+        $redis->sadd($key, @values);
 
-	    if($self->var_hosts()->{$host->{'node_name'}} && defined($host->{'host_variable'})){
+        if(scalar(keys %{$host->{'pending_replies'}}) == 0){
+            #$self->logger->error("Received all responses!");
+            $redis->expireat($key, $expires);
+
+            #our poll_id to time lookup
+            $redis->select(DB_POLLID_TO_KEY);
+            $redis->set($host->{'node_name'} . "," . $self->group_name . "," . $host->{'poll_id'}, $key);
+            $redis->set($ip . "," . $self->group_name . "," . $host->{'poll_id'}, $key);
+            #and expire
+            $redis->expireat($host->{'node_name'} . "," . $self->group_name . "," . $host->{'poll_id'}, $expires);
+            $redis->expireat($ip . "," . $self->group_name . "," . $host->{'poll_id'},$expires);
+
+            $redis->select(DB_MAIN);
+            #$self->logger->error(Dumper($host->{'group'}{$self->group_name}));
+
+            if($self->var_hosts()->{$host->{'node_name'}} && defined($host->{'host_variable'})){
 
                 $self->logger->debug("Adding host variables for $host->{'node_name'}");
 
-		my %add_values = %{$host->{'host_variable'}};
-		foreach my $name (keys %add_values){
-		    my $sanitized_name = $name;
-		    $sanitized_name =~ s/,//g; # we don't allow commas in variable names
-		    my $str = 'vars.' . $sanitized_name . "," . $add_values{$name}->{'value'};
-		    $redis->select(DB_MAIN);
-		    $redis->sadd($key, $str);
-		}
+                my %add_values = %{$host->{'host_variable'}};
+                foreach my $name (keys %add_values){
+                    my $sanitized_name = $name;
+                    $sanitized_name =~ s/,//g; # we don't allow commas in variable names
+                    my $str = 'vars.' . $sanitized_name . "," . $add_values{$name}->{'value'};
+                    $redis->select(DB_MAIN);
+                    $redis->sadd($key, $str);
+                }
 
-		$redis->select(DB_OID_MAP);
-		$redis->hset($host->{'node_name'}, "vars", $self->group_name . "," . $self->poll_interval);
-		$redis->hset($ip, "vars", $self->group_name . "," . $self->poll_interval);
-	    }
+                $redis->select(DB_OID_MAP);
+                $redis->hset($host->{'node_name'}, "vars", $self->group_name . "," . $self->poll_interval);
+                $redis->hset($ip, "vars", $self->group_name . "," . $self->poll_interval);
+            }
 
-	    #and the current poll_id lookup
-	    $redis->select(DB_CURRENT_POLLID);
-	    $redis->set($host->{'node_name'} . "," . $self->group_name, $host->{'poll_id'} . "," . $timestamp);
-	    $redis->set($ip . "," . $self->group_name, $host->{'poll_id'} . "," . $timestamp);
-	    #and expire
-	    $redis->expireat($host->{'node_name'} . "," . $self->group_name, $expires);
-	    $redis->expireat($ip . "," . $self->group_name, $expires);
+            #and the current poll_id lookup
+            $redis->select(DB_CURRENT_POLLID);
+            $redis->set($host->{'node_name'} . "," . $self->group_name, $host->{'poll_id'} . "," . $timestamp);
+            $redis->set($ip . "," . $self->group_name, $host->{'poll_id'} . "," . $timestamp);
+            #and expire
+            $redis->expireat($host->{'node_name'} . "," . $self->group_name, $expires);
+            $redis->expireat($ip . "," . $self->group_name, $expires);
 
-	    $host->{'poll_id'}++;
-	}
+            $host->{'poll_id'}++;
+        }
 
-	
-	$redis->select(DB_OID_MAP);
-	$redis->hset($host->{'node_name'}, $main_oid, $self->group_name . "," . $self->poll_interval);
-	$redis->hset($ip, $main_oid, $self->group_name . "," . $self->poll_interval);
 
-	#change back to the primary db...
-	$redis->select(DB_MAIN);
-	#complete the transaction
+        $redis->select(DB_OID_MAP);
+        $redis->hset($host->{'node_name'}, $main_oid, $self->group_name . "," . $self->poll_interval);
+        $redis->hset($ip, $main_oid, $self->group_name . "," . $self->poll_interval);
+
+        #change back to the primary db...
+        $redis->select(DB_MAIN);
+        #complete the transaction
     } catch {
-	$redis->select(DB_MAIN);
-	$self->logger->error($self->worker_name. " $id Error in hset for data: $_" );
+        $redis->select(DB_MAIN);
+        $self->logger->error($self->worker_name. " $id Error in hset for data: $_" );
     }
 
     if(scalar(keys %{$host->{'pending_replies'}}) == 0){
@@ -342,86 +342,86 @@ sub _connect_to_snmp{
     my $self = shift;
     my $hosts = $self->hosts;
     foreach my $host(@$hosts){
-	# build the SNMP object for each host of interest
-	my ($snmp,$error);
-	if(!defined($host->{'snmp_version'}) || $host->{'snmp_version'} eq '2c'){
-	    
-	    ($snmp, $error) = Net::SNMP->session(
-		-hostname         => $host->{'ip'},
-		-community        => $host->{'community'},
-		-version          => 'snmpv2c',
-		-timeout          => $self->snmp_timeout,
-		-maxmsgsize       => 65535,
-		-translate        => [-octetstring => 0],
-		-nonblocking      => 1,
-	    );
+        # build the SNMP object for each host of interest
+        my ($snmp,$error);
+        if(!defined($host->{'snmp_version'}) || $host->{'snmp_version'} eq '2c'){
 
-	    if(!defined($snmp)){
-		$self->logger->error("Error creating SNMP Session: " . $error);
-	    }
+            ($snmp, $error) = Net::SNMP->session(
+                -hostname         => $host->{'ip'},
+                -community        => $host->{'community'},
+                -version          => 'snmpv2c',
+                -timeout          => $self->snmp_timeout,
+                -maxmsgsize       => 65535,
+                -translate        => [-octetstring => 0],
+                -nonblocking      => 1,
+            );
 
-	    $self->{'snmp'}{$host->{'node_name'}} = $snmp;
+            if(!defined($snmp)){
+                $self->logger->error("Error creating SNMP Session: " . $error);
+            }
 
-	}elsif($host->{'snmp_version'} eq '3'){
-	    if(!defined($host->{'group'}{$self->group_name}{'context_id'})){
-		($snmp, $error) = Net::SNMP->session(
-		    -hostname         => $host->{'ip'},
-		    -version          => '3',
-		    -timeout          => $self->snmp_timeout,
-		    -maxmsgsize       => 65535,
-		    -translate        => [-octetstring => 0],
-		    -username         => $host->{'username'},
-		    -nonblocking      => 1,
-		    );
-		
-		if(!defined($snmp)){
-		    $self->logger->error("Error creating SNMP Session: " . $error);
-		}
-		
-		$self->{'snmp'}{$host->{'node_name'}} = $snmp;
-	    }else{
-		foreach my $ctxEngine (@{$host->{'group'}{$self->group_name}{'context_id'}}){
-		    ($snmp, $error) = Net::SNMP->session(
-			-hostname         => $host->{'ip'},
-			-version          => '3',
-			-timeout          => $self->snmp_timeout,
-			-maxmsgsize       => 65535,
-			-translate        => [-octetstring => 0],
-			-username         => $host->{'username'},
-			-nonblocking      => 1,
-			);
-		    
-		    if(!defined($snmp)){
-			$self->logger->error("Error creating SNMP Session: " . $error);
-		    }
-		    
-		    $self->{'snmp'}{$host->{'node_name'}}{$ctxEngine} = $snmp;
-		}
-	    }
-	}else{
-	    $self->logger->error("Invalid SNMP Version for SIMP");
-	}
-	
-	my $host_poll_id;
-	try{
-	    $self->redis->select(DB_CURRENT_POLLID);
-	    $host_poll_id = $self->redis->get($host->{'node_name'} . ",main_oid");
-	    $self->redis->select(DB_MAIN);
-	    
-	    if(!defined($host_poll_id)){
-		$host_poll_id = 0;
-	    }
+            $self->{'snmp'}{$host->{'node_name'}} = $snmp;
 
-	}catch{
-	    $self->redis->select(DB_MAIN);
-	    $host_poll_id = 0;
-	    $self->logger->error("Error fetching the current poll cycle id from redis: $_");
-	};
+        }elsif($host->{'snmp_version'} eq '3'){
+            if(!defined($host->{'group'}{$self->group_name}{'context_id'})){
+                ($snmp, $error) = Net::SNMP->session(
+                    -hostname         => $host->{'ip'},
+                    -version          => '3',
+                    -timeout          => $self->snmp_timeout,
+                    -maxmsgsize       => 65535,
+                    -translate        => [-octetstring => 0],
+                    -username         => $host->{'username'},
+                    -nonblocking      => 1,
+                    );
 
-	$host->{'poll_id'} = $host_poll_id;
-	$host->{'pending_replies'} = {};
-	
-	$self->logger->debug($self->worker_name . " assigned host " . $host->{'node_name'});
+                if(!defined($snmp)){
+                    $self->logger->error("Error creating SNMP Session: " . $error);
+                }
+
+                $self->{'snmp'}{$host->{'node_name'}} = $snmp;
+            }else{
+                foreach my $ctxEngine (@{$host->{'group'}{$self->group_name}{'context_id'}}){
+                    ($snmp, $error) = Net::SNMP->session(
+                        -hostname         => $host->{'ip'},
+                        -version          => '3',
+                        -timeout          => $self->snmp_timeout,
+                        -maxmsgsize       => 65535,
+                        -translate        => [-octetstring => 0],
+                        -username         => $host->{'username'},
+                        -nonblocking      => 1,
+                        );
+
+                    if(!defined($snmp)){
+                        $self->logger->error("Error creating SNMP Session: " . $error);
+                    }
+
+                    $self->{'snmp'}{$host->{'node_name'}}{$ctxEngine} = $snmp;
+                }
+            }
+        }else{
+            $self->logger->error("Invalid SNMP Version for SIMP");
+        }
+
+        my $host_poll_id;
+        try{
+            $self->redis->select(DB_CURRENT_POLLID);
+            $host_poll_id = $self->redis->get($host->{'node_name'} . ",main_oid");
+            $self->redis->select(DB_MAIN);
+
+            if(!defined($host_poll_id)){
+                $host_poll_id = 0;
+            }
+
+        }catch{
+            $self->redis->select(DB_MAIN);
+            $host_poll_id = 0;
+            $self->logger->error("Error fetching the current poll cycle id from redis: $_");
+        };
+
+        $host->{'poll_id'} = $host_poll_id;
+        $host->{'pending_replies'} = {};
+
+        $self->logger->debug($self->worker_name . " assigned host " . $host->{'node_name'});
     }
 }
 
@@ -436,78 +436,78 @@ sub _collect_data{
 
     for my $host (@$hosts){
 
-	if(scalar(keys %{$host->{'pending_replies'}}) > 0){
-	    $self->logger->error("Unable to query device " . $host->{'ip'} . ":" . $host->{'node_name'} . " in poll cycle for group: " . $self->group_name);
-	    next;
-	}
+        if(scalar(keys %{$host->{'pending_replies'}}) > 0){
+            $self->logger->error("Unable to query device " . $host->{'ip'} . ":" . $host->{'node_name'} . " in poll cycle for group: " . $self->group_name);
+            next;
+        }
 
         $cycle_cv->begin;
 
-	for my $oid (@$oids){
-	    if(!defined($self->{'snmp'}{$host->{'node_name'}})){
-		$self->logger->error("No SNMP session defined for " . $host->{'node_name'});
-		next;
-	    }
-	    my $reqstr = " $oid -> $host->{'ip'} ($host->{'node_name'})";
-	    $self->logger->debug($self->worker_name ." requesting ". $reqstr);
-	    #--- iterate through the the provided set of base OIDs to collect
-	    my $res;
+        for my $oid (@$oids){
+            if(!defined($self->{'snmp'}{$host->{'node_name'}})){
+                $self->logger->error("No SNMP session defined for " . $host->{'node_name'});
+                next;
+            }
+            my $reqstr = " $oid -> $host->{'ip'} ($host->{'node_name'})";
+            $self->logger->debug($self->worker_name ." requesting ". $reqstr);
+            #--- iterate through the the provided set of base OIDs to collect
+            my $res;
 
-	    if($host->{'snmp_version'} eq '2c'){
-		$host->{'pending_replies'}->{$oid} = 1;
-		$res = $self->{'snmp'}{$host->{'node_name'}}->get_table(
-		    -baseoid      => $oid,
-		    -maxrepetitions => $self->max_reps,
-		    -callback     => sub{ 
-			my $session = shift;
-			$self->_poll_cb( host => $host,
-					 timestamp => $timestamp,
-					 reqstr => $reqstr,
-					 oid => $oid,
-					 session => $session,
+            if($host->{'snmp_version'} eq '2c'){
+                $host->{'pending_replies'}->{$oid} = 1;
+                $res = $self->{'snmp'}{$host->{'node_name'}}->get_table(
+                    -baseoid      => $oid,
+                    -maxrepetitions => $self->max_reps,
+                    -callback     => sub{
+                        my $session = shift;
+                        $self->_poll_cb( host => $host,
+                                         timestamp => $timestamp,
+                                         reqstr => $reqstr,
+                                         oid => $oid,
+                                         session => $session,
                                          cycle_cv => $cycle_cv);
-		    }
-		    );
-	    }else{
-		#for each context engine specified for the group
-		if(!defined($host->{'group'}{$self->group_name}{'context_id'})){
-		    $host->{'pending_replies'}->{$oid} = 1;
-		    $res = $self->{'snmp'}{$host->{'node_name'}}->get_table(
-			-baseoid      => $oid,
-			-maxrepetitions => $self->max_reps,
-			-callback     => sub{
-			    my $session = shift;
-			    $self->_poll_cb( host => $host,
-					     timestamp => $timestamp,
-					     reqstr => $reqstr,
-					     oid => $oid,
-					     session => $session,
+                    }
+                    );
+            }else{
+                #for each context engine specified for the group
+                if(!defined($host->{'group'}{$self->group_name}{'context_id'})){
+                    $host->{'pending_replies'}->{$oid} = 1;
+                    $res = $self->{'snmp'}{$host->{'node_name'}}->get_table(
+                        -baseoid      => $oid,
+                        -maxrepetitions => $self->max_reps,
+                        -callback     => sub{
+                            my $session = shift;
+                            $self->_poll_cb( host => $host,
+                                             timestamp => $timestamp,
+                                             reqstr => $reqstr,
+                                             oid => $oid,
+                                             session => $session,
                                              cycle_cv => $cycle_cv);
-			}
-			);
-		    
-		}else{
-		    foreach my $ctxEngine (@{$host->{'group'}{$self->group_name}{'context_id'}}){
-			$host->{'pending_replies'}->{$oid . "," . $ctxEngine} = 1;
-			$res = $self->{'snmp'}{$host->{'node_name'}}{$ctxEngine}->get_table(
-			    -baseoid      => $oid,
-			    -maxrepetitions => $self->max_reps,
-			    -contextengineid => $ctxEngine,
-			    -callback     => sub{
-				my $session = shift;
-				$self->_poll_cb( host => $host,
-						 timestamp => $timestamp,
-						 reqstr => $reqstr,
-						 oid => $oid,
-						 context_id => $ctxEngine,
-						 session => $session,
+                        }
+                        );
+
+                }else{
+                    foreach my $ctxEngine (@{$host->{'group'}{$self->group_name}{'context_id'}}){
+                        $host->{'pending_replies'}->{$oid . "," . $ctxEngine} = 1;
+                        $res = $self->{'snmp'}{$host->{'node_name'}}{$ctxEngine}->get_table(
+                            -baseoid      => $oid,
+                            -maxrepetitions => $self->max_reps,
+                            -contextengineid => $ctxEngine,
+                            -callback     => sub{
+                                my $session = shift;
+                                $self->_poll_cb( host => $host,
+                                                 timestamp => $timestamp,
+                                                 reqstr => $reqstr,
+                                                 oid => $oid,
+                                                 context_id => $ctxEngine,
+                                                 session => $session,
                                                  cycle_cv => $cycle_cv);
-			    }
-			    );
-		    }
-		}
-	    }
-	}
+                            }
+                            );
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/lib/GRNOC/Simp/Poller/WorkerConfig.pm
+++ b/lib/GRNOC/Simp/Poller/WorkerConfig.pm
@@ -1,0 +1,97 @@
+package GRNOC::Simp::Poller::WorkerConfig;
+
+use GRNOC::Config;
+
+sub build_config {
+    my $conf_file = shift;
+    my $hosts_dir = shift;
+
+
+    my %groups;
+    # A list of hosts: { ip, snmp_version, community, node_name, {host_variable} }
+    my @hosts;
+    # For each host group, a list of the hosts belonging to the group
+    my %host_groups;
+
+
+    my $config = GRNOC::Config->new(
+        config_file => $self,
+        force_array => 1
+    );
+
+    foreach my $group (@{$config->get('/config/group')}) {
+        my %grp;
+
+        next if !$group->{'active'};
+
+        foreach my $i ('name', 'interval', 'snmp_timeout', 'max_reps', 'retention') {
+            $grp{$i} = $group->{$i};
+        }
+
+        my @workers;
+        my $num_workers = 0 + $group->{'workers'};
+        for (my $i = 0; $i < $num_workers; $i++) {
+            push @workers, "$grp{'name'}$i";
+        }
+        $grp{'workers'} = \@workers;
+
+        my $mib = $group->{'mib'};
+        $mib = [] if !defined($mib);
+        my @mib_mapped;
+        @mib_mapped = map { $_->{'oid'} } @$mib;
+        $grp{'mib'} = \@mib_mapped;
+
+        $groups{$grp{'name'}} = \%grp;
+    }
+
+
+
+    opendir my $dir, $hosts_dir;
+    my @hosts_files = readdir $dir;
+    closedir $dir;
+
+    foreach my $host_file (@host_files) {
+
+        next if $host_file !~ /\.xml$/; # so we don't ingest editor tempfiles, etc.
+
+        my $conf = GRNOC::Config->new(
+            config_file => "$hosts_dir/$host_file",
+            force_array => 1
+        );
+
+        foreach my $raw (@{$conf->get('/config/host')}) {
+            my %host;
+            for my $i ('node_name', 'ip', 'snmp_version', 'community', 'auth_key') {
+                $host{$i} = $raw->{$i};
+            }
+
+            if (defined($raw->{'host_variable'})) {
+                foreach my $var (keys @{$raw->{'host_variable'}}) {
+                    $host{'host_variable'}{$var} = $raw->{'host_variable'}{'value'};
+                }
+            }
+
+            $host{'groups'} = [];
+
+            if (defined($raw->{'group'})) {
+                foreach my $grp (keys @{$raw->{'group'}}) {
+                    next if !defined($groups{$grp});
+                    my $context_ids = $raw->{'group'}{$grp}{'context_id'};
+                    $context_ids = [] if !defined($context_ids);
+                    push @{$host_groups{$grp}}, [\%host, $context_ids] if defined($groups{$grp});
+                    push @{$host{'groups'}}, $grp;
+                }
+            }
+
+            push @hosts, \%host;
+        }
+    }
+
+    return {
+        groups      => \%groups,
+        hosts       => \@hosts,
+        host_groups => \%host_groups,
+    };
+}
+
+1;

--- a/lib/GRNOC/Simp/TSDS/Master.pm
+++ b/lib/GRNOC/Simp/TSDS/Master.pm
@@ -9,7 +9,7 @@ use Types::Standard qw(Str Bool);
 use Proc::Daemon;
 use AnyEvent::Subprocess;
 use POSIX qw(setuid setgid);
-use Data::Dumper; 
+use Data::Dumper;
 
 use GRNOC::Config;
 use GRNOC::RabbitMQ::Client;
@@ -77,7 +77,7 @@ my $running;
 
 sub BUILD {
     my $self = shift;
-    
+
     $self->_set_logger(Log::Log4perl->get_logger('GRNOC.Simp.TSDS.Master'));
 
     return $self;
@@ -90,54 +90,54 @@ sub BUILD {
 =cut
 sub start {
     my ($self) = @_;
-    
+
     $self->logger->info('Starting.');
     $self->logger->debug('Setting up signal handlers.');
 
 
     # Daemonize if needed
     if ($self->daemonize) {
-	$self->logger->debug('Daemonizing.');
+        $self->logger->debug('Daemonizing.');
 
-	my $daemon = Proc::Daemon->new( pid_file => $self->pidfile,
-				        child_STDOUT => '/tmp/oess-vlan-collector.out',
-				        child_STDERR => '/tmp/oess-vlan-collector.err');
-	my $pid = $daemon->Init();
+        my $daemon = Proc::Daemon->new( pid_file => $self->pidfile,
+                                        child_STDOUT => '/tmp/oess-vlan-collector.out',
+                                        child_STDERR => '/tmp/oess-vlan-collector.err');
+        my $pid = $daemon->Init();
 
-	if ($pid) {
-	    sleep 1;
-	    die 'Spawning child process failed' if !$daemon->Status();
-	    exit(0);
-	}
+        if ($pid) {
+            sleep 1;
+            die 'Spawning child process failed' if !$daemon->Status();
+            exit(0);
+        }
     }
 
     warn "Child is alive!!\n";
 
     # If requested, change to different user and group
     if (defined($self->run_group)) {
-	my $run_group = $self->run_group;
-	my $gid = getpwnam($self->run_group);
-	die "Unable to get GID for group '$run_group'\n" if !defined($gid);
-	$! = 0;
-	setgid($gid);
-	die "Unable to set GID to '$run_group' ($gid): $!\n" if $! != 0;
+        my $run_group = $self->run_group;
+        my $gid = getpwnam($self->run_group);
+        die "Unable to get GID for group '$run_group'\n" if !defined($gid);
+        $! = 0;
+        setgid($gid);
+        die "Unable to set GID to '$run_group' ($gid): $!\n" if $! != 0;
     }
 
     if (defined($self->run_user)) {
-	my $run_user = $self->run_user;
-	my $uid = getpwnam($run_user);
-	die "Unable to get UID for user '$run_user'\n" if !defined($uid);
-	$! = 0;
-	setuid($uid);
-	die "Unable to set UID to '$run_user' ($uid): $!\n" if $! != 0;
+        my $run_user = $self->run_user;
+        my $uid = getpwnam($run_user);
+        die "Unable to get UID for user '$run_user'\n" if !defined($uid);
+        $! = 0;
+        setuid($uid);
+        die "Unable to set UID to '$run_user' ($uid): $!\n" if $! != 0;
     }
 
     # Only run once unless HUP gets set, then reload and go again
     while (1) {
         $self->_set_hup(0);
-	$self->_load_config();
-	$self->_create_workers();
-	last unless $self->hup;
+        $self->_load_config();
+        $self->_create_workers();
+        last unless $self->hup;
     }
 
     $self->logger->info("Master terminating");
@@ -152,12 +152,12 @@ sub _load_config {
     $self->logger->info("Reading configuration from " . $self->config_file);
 
     my $conf = GRNOC::Config->new(config_file => $self->config_file,
-				       force_array => 1);
+                                       force_array => 1);
 
     $self->_set_simp_config($conf->get('/config/simp')->[0]);
 
     $self->_set_tsds_config($conf->get('/config/tsds')->[0]);
-    
+
     $self->_set_collections($conf->get('/config/collection'));
 
     # Sanity-check some of the collection parameters
@@ -215,11 +215,11 @@ sub _create_workers {
     $running = AnyEvent->condvar;
 
     $SIG{'TERM'} = sub {
-	$self->logger->info('Received SIGTERM.');
-	foreach my $worker (@{$self->children}){
-	    $worker->kill();
-	}
-	exit;
+        $self->logger->info('Received SIGTERM.');
+        foreach my $worker (@{$self->children}){
+            $worker->kill();
+        }
+        exit;
     };
 
     $SIG{'INT'} = sub {
@@ -231,13 +231,13 @@ sub _create_workers {
     };
 
     $SIG{'HUP'} = sub {
-	$self->logger->info('Received SIGHUP.');
-	while(my $worker = pop @{$self->children}){
+        $self->logger->info('Received SIGHUP.');
+        while(my $worker = pop @{$self->children}){
             $worker->kill();
         }
-	
-	$self->_set_hup(1);	
-	$running->send;
+
+        $self->_set_hup(1);
+        $running->send;
     };
 
     $running->recv;
@@ -252,20 +252,20 @@ sub _create_workers_for_one_collection {
     # Divide up hosts in config among number of workers defined in config
     foreach my $host (@{$collection->{'host'}}) {
         next if !defined($host) || (ref($host) ne '');
-	push(@{$hosts_by_worker{$idx}}, $host);
-	$idx++;
-	if ($idx >= $collection->{'workers'}) {
-	    $idx = 0;
-	}
+        push(@{$hosts_by_worker{$idx}}, $host);
+        $idx++;
+        if ($idx >= $collection->{'workers'}) {
+            $idx = 0;
+        }
     }
 
     # Spawn workers
     foreach my $worker_id (keys %hosts_by_worker) {
-	my $worker_name = "$collection->{'composite-name'}_$worker_id";
+        my $worker_name = "$collection->{'composite-name'}_$worker_id";
 
-	$self->_create_worker( name       => $worker_name,
+        $self->_create_worker( name       => $worker_name,
                                collection => $collection,
-			       hosts      => $hosts_by_worker{$worker_id});
+                               hosts      => $hosts_by_worker{$worker_id});
     }
 }
 

--- a/lib/GRNOC/Simp/TSDS/Pusher.pm
+++ b/lib/GRNOC/Simp/TSDS/Pusher.pm
@@ -30,13 +30,13 @@ use constant SERVICE_CACHE_FILE => "/etc/grnoc/name-service-cacher/name-service.
 =cut
 
 has logger => (is => 'rwp',
-	       required => 1);
+               required => 1);
 
 has worker_name => (is => 'ro',
-		    required => 1);
+                    required => 1);
 
 has tsds_config => (is => 'rwp',
-		    required => 1);
+                    required => 1);
 
 has tsds_svc => (is => 'rwp');
 
@@ -49,14 +49,14 @@ sub BUILD {
 
     # Set up our TSDS webservice object when construcuted
     $self->_set_tsds_svc(GRNOC::WebService::Client->new(
-			     url => $self->tsds_config->{'url'},
-			     # urn => $self->tsds_config->{'urn'},
-			     uid => $self->tsds_config->{'user'},
-			     passwd => $self->tsds_config->{'password'},
-			     # realm => $self->tsds_config->{'realm'},
-			     # service_cache_file => SERVICE_CACHE_FILE,
-			     usePost => 1
-			 ));
+                             url => $self->tsds_config->{'url'},
+                             # urn => $self->tsds_config->{'urn'},
+                             uid => $self->tsds_config->{'user'},
+                             passwd => $self->tsds_config->{'password'},
+                             # realm => $self->tsds_config->{'realm'},
+                             # service_cache_file => SERVICE_CACHE_FILE,
+                             usePost => 1
+                         ));
 }
 
 =head2 push
@@ -68,15 +68,15 @@ sub push {
 
     # Push messages to TSDS in MAX_TSDS_MESSAGES chunks
     if (scalar @$msg_list > 0) {
-	my @msgs = splice(@$msg_list, 0, MAX_TSDS_MESSAGES);
-	$self->logger->info($self->worker_name . " Pushing " . scalar @msgs . " messages to TSDS");
-	my $res = $self->tsds_svc->add_data(
-	    data => encode_json(\@msgs)
-	);
-	if (!defined($res) || $res->{'error'}) {
-	    $self->logger->error($self->worker_name . " Error pushing data to TSDS: " . GRNOC::Simp::TSDS::error_message($res));
-	}
-	return 1;
+        my @msgs = splice(@$msg_list, 0, MAX_TSDS_MESSAGES);
+        $self->logger->info($self->worker_name . " Pushing " . scalar @msgs . " messages to TSDS");
+        my $res = $self->tsds_svc->add_data(
+            data => encode_json(\@msgs)
+        );
+        if (!defined($res) || $res->{'error'}) {
+            $self->logger->error($self->worker_name . " Error pushing data to TSDS: " . GRNOC::Simp::TSDS::error_message($res));
+        }
+        return 1;
     }
     $self->logger->info($self->worker_name . " Nothing to push to TSDS");
     return;

--- a/lib/GRNOC/Simp/TSDS/Worker.pm
+++ b/lib/GRNOC/Simp/TSDS/Worker.pm
@@ -46,28 +46,28 @@ use GRNOC::Simp::TSDS::Pusher;
 =cut
 
 has worker_name => (is => 'ro',
-		    required => 1);
+                    required => 1);
 
 has logger => (is => 'rwp',
-	       required => 1);
+               required => 1);
 
 has simp_config => (is => 'rwp',
-		    required => 1);
+                    required => 1);
 
 has tsds_config => (is => 'rwp',
-		    required => 1);
+                    required => 1);
 
 has hosts => (is => 'rwp',
-	      required => 1);
+              required => 1);
 
 has tsds_type => (is => 'rwp',
                   required => 1);
 
 has interval => (is => 'rwp',
-		 required => 1);
+                 required => 1);
 
 has composite_name => (is => 'rwp',
-		       required => 1);
+                       required => 1);
 
 has filter_name => (is => 'rwp');
 has filter_value => (is => 'rwp');
@@ -93,7 +93,7 @@ has required_value_fields => (is => 'rwp', default => sub { [] });
 
 =item stop_me
 
-=back 
+=back
 
 =cut
 
@@ -136,39 +136,39 @@ sub _load_config {
 
     # Create dispatcher to watch for messages from Master
     my $dispatcher = GRNOC::RabbitMQ::Dispatcher->new(
-	host => $self->simp_config->{'host'},
-	port => $self->simp_config->{'port'},
-	user => $self->simp_config->{'user'},
-	pass => $self->simp_config->{'password'},
-	exchange => 'SNAPP',
-	topic    => "SNAPP." . $self->worker_name
+        host => $self->simp_config->{'host'},
+        port => $self->simp_config->{'port'},
+        user => $self->simp_config->{'user'},
+        pass => $self->simp_config->{'password'},
+        exchange => 'SNAPP',
+        topic    => "SNAPP." . $self->worker_name
     );
 
     # Create and register stop method
     my $stop_method = GRNOC::RabbitMQ::Method->new(
-	name        => "stop",
-	description => "stops worker",
-	callback => sub {
-	    $self->_set_stop_me(1);
-	}
+        name        => "stop",
+        description => "stops worker",
+        callback => sub {
+            $self->_set_stop_me(1);
+        }
     );
     $dispatcher->register_method($stop_method);
 
     # Create SIMP client object
     $self->_set_simp_client(GRNOC::RabbitMQ::Client->new(
-	host => $self->simp_config->{'host'},
-	port => $self->simp_config->{'port'},
-	user => $self->simp_config->{'user'},
-	pass => $self->simp_config->{'password'},
-	exchange => 'Simp',
-	topic    => 'Simp.CompData'
+        host => $self->simp_config->{'host'},
+        port => $self->simp_config->{'port'},
+        user => $self->simp_config->{'user'},
+        pass => $self->simp_config->{'password'},
+        exchange => 'Simp',
+        topic    => 'Simp.CompData'
     ));
 
     # Create TSDS Pusher object
     $self->_set_tsds_pusher(GRNOC::Simp::TSDS::Pusher->new(
-	logger => $self->logger,
-	worker_name => $self->worker_name,
-	tsds_config => $self->tsds_config,
+        logger => $self->logger,
+        worker_name => $self->worker_name,
+        tsds_config => $self->tsds_config,
     ));
 
     # set interval
@@ -179,43 +179,43 @@ sub _load_config {
 
     # Create polling timer for event loop
     $self->_set_poll_w(AnyEvent->timer(
-	after => 5,
-	interval => $interval,
-	cb => sub {
-	    my $tm = time;
-	
-	    # Pull data for each host from Comp
-	    foreach my $host (@{$self->hosts}) {
-		$self->logger->info($self->worker_name . " processing $host");
-		
-		my %args = (
-		    node           => $host,
-		    period         => $interval,
-		    async_callback => sub {
-			my $res = shift;
-			
-			# Process results and push when idle
-			$self->_process_host($res, $tm);
-			$self->_set_push_w(AnyEvent->idle(cb => sub { $self->_push_data; }));
-		    }
-		    );
+        after => 5,
+        interval => $interval,
+        cb => sub {
+            my $tm = time;
 
-		# if we're trying to only get a subset of values out of simp,
- 		# add those arguments now. This presumes that SIMP and SIMP-collector
-		# have been correctly configured to have the data available
-		# validity is checked for earlier in Master
-		if ($self->filter_name){
-		    $args{$self->filter_name} = $self->filter_value;
-		}
+            # Pull data for each host from Comp
+            foreach my $host (@{$self->hosts}) {
+                $self->logger->info($self->worker_name . " processing $host");
 
-		$self->simp_client->$composite(%args);
-	    }
+                my %args = (
+                    node           => $host,
+                    period         => $interval,
+                    async_callback => sub {
+                        my $res = shift;
 
-	    # Push when idle
-	    $self->_set_push_w(AnyEvent->idle(cb => sub { $self->_push_data; }));
-	}
+                        # Process results and push when idle
+                        $self->_process_host($res, $tm);
+                        $self->_set_push_w(AnyEvent->idle(cb => sub { $self->_push_data; }));
+                    }
+                    );
+
+                # if we're trying to only get a subset of values out of simp,
+                # add those arguments now. This presumes that SIMP and SIMP-collector
+                # have been correctly configured to have the data available
+                # validity is checked for earlier in Master
+                if ($self->filter_name){
+                    $args{$self->filter_name} = $self->filter_value;
+                }
+
+                $self->simp_client->$composite(%args);
+            }
+
+            # Push when idle
+            $self->_set_push_w(AnyEvent->idle(cb => sub { $self->_push_data; }));
+        }
     ));
-    
+
     $self->logger->info($self->worker_name . " Done setting up event callbacks");
 }
 
@@ -227,8 +227,8 @@ sub _process_host {
 
     # Drop out if we get an error from Comp
     if (!defined($res) || $res->{'error'}) {
-	$self->logger->error($self->worker_name . " Comp error: " . GRNOC::Simp::TSDS::error_message($res));
-	return;
+        $self->logger->error($self->worker_name . " Comp error: " . GRNOC::Simp::TSDS::error_message($res));
+        return;
     }
 
     my $required_values = $self->required_value_fields;
@@ -236,47 +236,47 @@ sub _process_host {
     # Take data from Comp and "package" for a post to TSDS
     foreach my $node_name (keys %{$res->{'results'}}) {
 
-	$self->logger->debug($self->worker_name . ' Name: ' . Dumper($node_name));
-	$self->logger->debug($self->worker_name . ' Value: ' . Dumper($res->{'results'}->{$node_name}));
+        $self->logger->debug($self->worker_name . ' Name: ' . Dumper($node_name));
+        $self->logger->debug($self->worker_name . ' Value: ' . Dumper($res->{'results'}->{$node_name}));
 
-	my $data = $res->{'results'}->{$node_name};
-	foreach my $datum_name (keys %{$data}) {
-	    my $datum = $data->{$datum_name};
-	    my %vals;
-	    my %meta;
-	    my $datum_tm = $tm;
+        my $data = $res->{'results'}->{$node_name};
+        foreach my $datum_name (keys %{$data}) {
+            my $datum = $data->{$datum_name};
+            my %vals;
+            my %meta;
+            my $datum_tm = $tm;
 
             # this works properly when required_value_fields is empty,
             # as any returns false then
             next if (any { !defined($datum->{$_}) } @$required_values);
 
-	    foreach my $key (keys %{$datum}) {
+            foreach my $key (keys %{$datum}) {
                 # This is commented out for now due to a bug in TSDS (3135:160)
                 # where bad things happen if a key is sent some of the time
                 # (as opposed to all the time or none of the time):
                 #next if !defined($datum->{$key});
 
-		if ($key eq 'time') {
-		    next if !defined($datum->{$key}); # workaround for 3135:160
-		    $datum_tm = $datum->{$key} + 0;
-		} elsif ($key =~ /^\*/) {
-		    my $meta_key = substr($key, 1);
-		    $meta{$meta_key} = $datum->{$key};
-		} else {
+                if ($key eq 'time') {
+                    next if !defined($datum->{$key}); # workaround for 3135:160
+                    $datum_tm = $datum->{$key} + 0;
+                } elsif ($key =~ /^\*/) {
+                    my $meta_key = substr($key, 1);
+                    $meta{$meta_key} = $datum->{$key};
+                } else {
                     # this can be simplified once 3135:160 is fixed
-		    $vals{$key} = (defined($datum->{$key})) ? $datum->{$key} + 0 : undef;
-		}
-	    }
+                    $vals{$key} = (defined($datum->{$key})) ? $datum->{$key} + 0 : undef;
+                }
+            }
 
-	    # push onto our queue for posting to TSDS
-	    push @{$self->msg_list}, {
-		type => $self->tsds_type,
-		time => $datum_tm,
-		interval => $self->interval,
-		values => \%vals,
-		meta => \%meta
-	    };
-	}
+            # push onto our queue for posting to TSDS
+            push @{$self->msg_list}, {
+                type => $self->tsds_type,
+                time => $datum_tm,
+                interval => $self->interval,
+                values => \%vals,
+                meta => \%meta
+            };
+        }
     }
 }
 
@@ -291,11 +291,11 @@ sub _push_data {
     $self->logger->debug( Dumper($res) );
 
     unless ($res) {
-	# If queue is empty and stop flag is set, end event loop
-	$self->cv->send() if $self->stop_me;
-	# Otherwise clear push timer
-	$self->_set_push_w(undef);
-	exit(0) if $self->stop_me;
+        # If queue is empty and stop flag is set, end event loop
+        $self->cv->send() if $self->stop_me;
+        # Otherwise clear push timer
+        $self->_set_push_w(undef);
+        exit(0) if $self->stop_me;
     }
 }
 

--- a/perl-GRNOC-Simp-Poller-Config.spec
+++ b/perl-GRNOC-Simp-Poller-Config.spec
@@ -1,0 +1,41 @@
+Summary: Config-file parsing for simp-poller and related programs
+Name: perl-GRNOC-Simp-Poller-Config
+Version: 1.0.6
+Release: 1%{dist}
+License: GRNOC
+Group: GRNOC
+URL: http://globalnoc.iu.edu/simp
+Source0: poller-config-%{version}.tar.gz
+
+BuildRequires: perl
+BuildRequires: perl(Test::Deep)
+BuildRequires: perl(Test::More)
+BuildRequires: perl(Test::Pod) >= 1.22
+
+Requires: perl(GRNOC::Config)
+
+Provides: perl(GRNOC::Simp::Poller::Config)
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+
+%description
+
+%prep
+%setup -q -n poller-config-%{version}
+
+%build
+
+%install
+rm -rf $RPM_BUILD_ROOT
+%{__install} -d -p %{buildroot}%{perl_vendorlib}/GRNOC/Simp/Poller
+
+ls -lR lib
+%{__install} lib/GRNOC/Simp/Poller/Config.pm %{buildroot}%{perl_vendorlib}/GRNOC/Simp/Poller/Config.pm
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%files
+%defattr(644,root,root,755)
+%{perl_vendorlib}/GRNOC/Simp/Poller/Config.pm
+
+%changelog

--- a/perl-GRNOC-Simp-Poller-Config.spec
+++ b/perl-GRNOC-Simp-Poller-Config.spec
@@ -28,7 +28,6 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 rm -rf $RPM_BUILD_ROOT
 %{__install} -d -p %{buildroot}%{perl_vendorlib}/GRNOC/Simp/Poller
 
-ls -lR lib
 %{__install} lib/GRNOC/Simp/Poller/Config.pm %{buildroot}%{perl_vendorlib}/GRNOC/Simp/Poller/Config.pm
 
 %clean

--- a/simp-poller.spec
+++ b/simp-poller.spec
@@ -20,7 +20,6 @@ Requires: perl(List::MoreUtils)
 Requires: perl(Data::Munge)
 Requires: perl-GRNOC-Log
 Requires: perl-GRNOC-Config
-Requires: perl(GRNOC::Simp::Poller::Config)
 Requires: perl-Moo
 Requires: perl-Net-SNMP
 Requires: perl-Parallel-ForkManager

--- a/simp-poller.spec
+++ b/simp-poller.spec
@@ -15,8 +15,8 @@ BuildRequires: perl(Test::Pod) >= 1.22
 Requires: redis
 Requires: perl(AnyEvent)
 Requires: perl(AnyEvent::SNMP)
-Requires: perl(List::Util)
 Requires: perl(List::MoreUtils)
+Requires: perl(List::Util)
 Requires: perl(Data::Munge)
 Requires: perl-GRNOC-Log
 Requires: perl-GRNOC-Config

--- a/simp-poller.spec
+++ b/simp-poller.spec
@@ -15,10 +15,12 @@ BuildRequires: perl(Test::Pod) >= 1.22
 Requires: redis
 Requires: perl(AnyEvent)
 Requires: perl(AnyEvent::SNMP)
+Requires: perl(List::Util)
 Requires: perl(List::MoreUtils)
 Requires: perl(Data::Munge)
 Requires: perl-GRNOC-Log
 Requires: perl-GRNOC-Config
+Requires: perl(GRNOC::Simp::Poller::Config)
 Requires: perl-Moo
 Requires: perl-Net-SNMP
 Requires: perl-Parallel-ForkManager
@@ -50,6 +52,7 @@ rm -rf $RPM_BUILD_ROOT
 
 %{__install} lib/GRNOC/Simp/Poller.pm %{buildroot}%{perl_vendorlib}/GRNOC/Simp/Poller.pm
 %{__install} lib/GRNOC/Simp/Poller/Worker.pm %{buildroot}%{perl_vendorlib}/GRNOC/Simp/Poller/Worker.pm
+%{__install} lib/GRNOC/Simp/Poller/Config.pm %{buildroot}%{perl_vendorlib}/GRNOC/Simp/Poller/Config.pm
 %{__install} bin/simp-poller.pl %{buildroot}/usr/bin/simp-poller.pl
 %{__install} conf/config.xml %{buildroot}/etc/simp/
 %{__install} conf/logging.conf %{buildroot}/etc/simp/poller_logging.conf
@@ -63,6 +66,7 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(644,root,root,755)
 %{perl_vendorlib}/GRNOC/Simp/Poller.pm
 %{perl_vendorlib}/GRNOC/Simp/Poller/Worker.pm
+%{perl_vendorlib}/GRNOC/Simp/Poller/Config.pm
 %defattr(755,root,root,755)
 /usr/bin/simp-poller.pl
 /etc/init.d/simp-poller

--- a/simp-poller.spec
+++ b/simp-poller.spec
@@ -31,7 +31,6 @@ Requires: perl-Type-Tiny
 
 Provides: perl(GRNOC::Simp::Poller)
 Provides: perl(GRNOC::Simp::Poller::Worker)
-Provides: perl(GRNOC::Simp::Poller::Config)
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
 %description
@@ -54,7 +53,6 @@ rm -rf $RPM_BUILD_ROOT
 
 %{__install} lib/GRNOC/Simp/Poller.pm %{buildroot}%{perl_vendorlib}/GRNOC/Simp/Poller.pm
 %{__install} lib/GRNOC/Simp/Poller/Worker.pm %{buildroot}%{perl_vendorlib}/GRNOC/Simp/Poller/Worker.pm
-%{__install} lib/GRNOC/Simp/Poller/Config.pm %{buildroot}%{perl_vendorlib}/GRNOC/Simp/Poller/Config.pm
 %{__install} bin/simp-poller.pl %{buildroot}/usr/bin/simp-poller.pl
 %{__install} conf/config.xml %{buildroot}/etc/simp/
 %{__install} conf/logging.conf %{buildroot}/etc/simp/poller_logging.conf
@@ -68,7 +66,6 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(644,root,root,755)
 %{perl_vendorlib}/GRNOC/Simp/Poller.pm
 %{perl_vendorlib}/GRNOC/Simp/Poller/Worker.pm
-%{perl_vendorlib}/GRNOC/Simp/Poller/Config.pm
 %defattr(755,root,root,755)
 /usr/bin/simp-poller.pl
 /etc/init.d/simp-poller

--- a/simp-poller.spec
+++ b/simp-poller.spec
@@ -20,6 +20,7 @@ Requires: perl(List::MoreUtils)
 Requires: perl(Data::Munge)
 Requires: perl-GRNOC-Log
 Requires: perl-GRNOC-Config
+Requires: perl(GRNOC::Simp::Poller::Config)
 Requires: perl-Moo
 Requires: perl-Net-SNMP
 Requires: perl-Parallel-ForkManager
@@ -29,6 +30,8 @@ Requires: perl-Try-Tiny
 Requires: perl-Type-Tiny
 
 Provides: perl(GRNOC::Simp::Poller)
+Provides: perl(GRNOC::Simp::Poller::Worker)
+Provides: perl(GRNOC::Simp::Poller::Config)
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
 %description

--- a/t/00-load.t
+++ b/t/00-load.t
@@ -6,6 +6,7 @@ use lib './lib';
 BEGIN {
         use_ok( 'GRNOC::Simp::Poller' );
         use_ok( 'GRNOC::Simp::Poller::Worker' );
+        use_ok( 'GRNOC::Simp::Poller::Config' );
         use_ok( 'GRNOC::Simp::Data' );
         use_ok( 'GRNOC::Simp::Data::Worker' );
         use_ok( 'GRNOC::Simp::CompData' );

--- a/t/00-load.t
+++ b/t/00-load.t
@@ -10,8 +10,8 @@ BEGIN {
         use_ok( 'GRNOC::Simp::Data::Worker' );
         use_ok( 'GRNOC::Simp::CompData' );
         use_ok( 'GRNOC::Simp::CompData::Worker' );
-	use_ok( 'GRNOC::Simp::TSDS');
-	use_ok( 'GRNOC::Simp::TSDS::Pusher');
-	use_ok( 'GRNOC::Simp::TSDS::Worker');
-	use_ok( 'GRNOC::Simp::TSDS::Master');
+        use_ok( 'GRNOC::Simp::TSDS');
+        use_ok( 'GRNOC::Simp::TSDS::Pusher');
+        use_ok( 'GRNOC::Simp::TSDS::Worker');
+        use_ok( 'GRNOC::Simp::TSDS::Master');
 }

--- a/t/41-data-basic.t
+++ b/t/41-data-basic.t
@@ -61,7 +61,7 @@ cmp_deeply(
     {
       'c.example.net_1' => {
         '1.3.6.1.2.1.2.2.1.11.1' => { 'value' => '0.225225225225225',
-				      'time' => 100131 },
+                                      'time' => 100131 },
       },
     },
     'request 2: we got the correct data in the response'


### PR DESCRIPTION
We would like to be able to monitor `simp-poller` at a finer granularity than "are the workers running or not?". This pull request includes the poller-side work for this: `simp-poller` workers now maintain two sorts of information in a new Redis database (in the same Redis instance to which it writes other data):

* A per-worker heartbeat, updated once per poll cycle.
* A per-(host,&nbsp;group) record of poll status for the last _N_ poll cycles, to be able to see (to first approximation) what collections are working and which are not.

As part of this, the code that extracts information from `config.xml` and `hosts.d/*.xml` has been split off into its own module, `GRNOC::Simp::Poller::Config`, which is in a package of its own to facilitate use by out-of-tree monitoring checks.

This also contains a couple other miscellaneous things:

* I converted tabs in source code to spaces, and removed trailing spaces from lines.
* I changed the `simp-poller` worker names to remove a potential ambiguity where different workers could have the same name. (This broke `simp-data`, so I fixed that.)

This PR should only be merged after #71 and #72, as the whitespace normalization let to the work on this branch being coupled to the work in those branches &mdash; mea culpa.