### PR TITLE
SCTASK0025381 make simp-tsds work with Kerberos Auth

### DIFF
--- a/lib/GRNOC/Simp/TSDS/Pusher.pm
+++ b/lib/GRNOC/Simp/TSDS/Pusher.pm
@@ -53,7 +53,7 @@ sub BUILD {
 			     # urn => $self->tsds_config->{'urn'},
 			     uid => $self->tsds_config->{'user'},
 			     passwd => $self->tsds_config->{'password'},
-			     # realm => $self->tsds_config->{'realm'},
+			     realm => $self->tsds_config->{'realm'},
 			     # service_cache_file => SERVICE_CACHE_FILE,
 			     usePost => 1
 			 ));


### PR DESCRIPTION
Simp-tsds can't push data properly with Kerberos auth, because realm is not configurable.
Uncommenting 'realm' solves this problem.
