### PR TITLE
SCTASK0035424 add dropping of records in simp-comp

### DIFF
--- a/conf/comp/composite.xsd
+++ b/conf/comp/composite.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
 
-    <!-- Composite definition (document root) -->    
+    <!-- Composite definition (document root) -->
     <xsd:element name="composite" type="COMPOSITE"/>
 
     <xsd:complexType name="COMPOSITE">
@@ -38,7 +38,6 @@
         <xsd:attribute name="value" type="xsd:string" use="required"/>
     </xsd:complexType>
 
-
     <!-- Data element definitions -->
     <xsd:complexType name="DATA">
         <xsd:choice minOccurs="2" maxOccurs="unbounded">
@@ -48,14 +47,16 @@
     </xsd:complexType>
 
     <xsd:complexType name="META">
-        <xsd:attribute name="name"   type="VAR_NAME"   use="required"/>
-        <xsd:attribute name="source" type="VAR_SOURCE" use="required"/>
+        <xsd:attribute name="name"          type="VAR_NAME"   use="required"/>
+        <xsd:attribute name="source"        type="VAR_SOURCE" use="required"/>
+        <xsd:attribute name="require_match" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="VALUE">
-        <xsd:attribute name="name"   type="VAR_NAME"   use="required"/>
-        <xsd:attribute name="source" type="VAR_SOURCE" use="required"/>
-	<xsd:attribute name="type"   type="VAR_TYPE"/>
+        <xsd:attribute name="name"          type="VAR_NAME"   use="required"/>
+        <xsd:attribute name="source"        type="VAR_SOURCE" use="required"/>
+        <xsd:attribute name="require_match" type="xsd:string" />
+	    <xsd:attribute name="type"          type="VAR_TYPE"/>
     </xsd:complexType>
 
     <!-- Conversions element definitions -->
@@ -101,9 +102,6 @@
         <xsd:attribute name="exclude" type="INT_BOOL"/>
     </xsd:complexType>
 
-    
-
-
 <!-- Global simpleType Definitions -->
 
     <!-- Validates Variable Names -->
@@ -148,5 +146,4 @@
             <xsd:enumeration value="replace"/>
         </xsd:restriction>
     </xsd:simpleType>
-
 </xsd:schema>

--- a/lib/GRNOC/Simp/Comp/Worker.pm
+++ b/lib/GRNOC/Simp/Comp/Worker.pm
@@ -1358,13 +1358,28 @@ sub _digest_data
         # all the keys are present. If some OIDs hadn't been collected
         # we wouldn't have entries for them, but we always want the complete
         # composite returned as defined.
-        for my $val_datum (@val_data)
+
+        # We also take this opportunity to throw away results where a field
+        # was marked required, but it doesn't match the require regex
+        for (my $i = $#val_data; $i >= 0; $i--)
         {
+            my $val_datum = $val_data[$i];
+
             for my $data_element (@data_elements)
             {
                 my $data_el_name = $data_element->{'name'};
+
                 $val_datum->{$data_el_name} = undef
-                  if (!exists $val_datum->{$data_el_name});
+                  if (!exists($val_datum->{$data_el_name}));
+
+                if (exists($data_element->{'require_match'})
+                    && $val_datum->{$data_el_name} !~
+                    $data_element->{'require_match'})
+                {
+                    splice(@val_data, $i, 1);
+
+                    last;
+                }
             }
         }
 


### PR DESCRIPTION
this patch adds a tag to the fields in composite data meta/value fields: require_match.
the field is optional.
if a value does not conform to the regex in this field, the entire record will be dropped.
