### PR TITLE
Redis re-connection fix

### DIFF
--- a/lib/GRNOC/Simp/Data/Worker.pm
+++ b/lib/GRNOC/Simp/Data/Worker.pm
@@ -408,6 +408,10 @@ sub _find_groups {
     return $groups;
 }
 
+=head2 _connect_to_redis()
+     Helper function that helps connecting to the redis server 
+     and returns the redis object reference
+=cut
 sub _connect_to_redis {
     my ($self) = @_;
 
@@ -433,6 +437,7 @@ sub _connect_to_redis {
     my $redis;
     my $redis_connected = 0;
 
+    # Try reconnecting to redis. Only continue when redis is connected. 
     while (!$redis_connected) {
         try {
             $redis = Redis::Fast->new(

--- a/lib/GRNOC/Simp/Data/Worker.pm
+++ b/lib/GRNOC/Simp/Data/Worker.pm
@@ -415,6 +415,12 @@ sub _find_groups {
 sub _connect_to_redis {
     my ($self) = @_;
 
+    # If redis server is still up, use the
+    # already instantiated redis object
+    if ($self->redis && $self->redis->ping()) { 
+        return $self->redis; 
+    }
+
     # Get Redis configuration variables
     my $redis_host            = $self->config->get('/config/redis/@ip');
     my $redis_port            = $self->config->get('/config/redis/@port');

--- a/lib/GRNOC/Simp/Poller/Worker.pm
+++ b/lib/GRNOC/Simp/Poller/Worker.pm
@@ -205,6 +205,10 @@ sub stop {
     $self->main_cv->send();
 }
 
+=head2 _connect_to_redis()
+     Helper function that helps connecting to the redis server 
+     and returns the redis object reference
+=cut
 sub _connect_to_redis {
     my ($self, $worker) = @_;
 
@@ -224,6 +228,7 @@ sub _connect_to_redis {
     my $redis;
     my $redis_connected = 0;
 
+    # Try reconnecting to redis. Only continue when redis is connected.
     while(!$redis_connected) {
         try {
             # Try to connect twice per second for 30 seconds,


### PR DESCRIPTION
simp-data and simp-poller workers fail to re-connect to the Redis server when the server goes down and comes back up after a while. This fix lets simp poller and data workers to keep trying to re-connect to redis before proceeding further.