### PR TITLE
SCTASK0104379 - Version 1.11.0 Release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,18 @@
-# Simp ChangeLog
+# SIMP ChangeLog
+
+## 1.11.0 - Dec 22, 2022
+* Added simp-poller support for multiple host configurations for a single host
+* Added simp-poller support for all Net::SNMP parameters
+* Added simp-poller support for logging group worker configuration parameters at startup
+* Improved simp-poller worker configuration handling
+* Improved simp-poller worker balancing in preparation for automatic worker scaling
+* Fixed issue where simp-poller would not allow remote Redis server configuration
+* Fixed issue where simp-poller would not properly identify failing SNMP requests for status monitoring
+* Fixed issue where simp-poller would discard status monitoring data for hosts with multiple SNMP configurations
+* Fixed issue where simp-poller would spawn zombie workers with no hosts configured for their group
+* Fixed issue where simp-poller would ignore additional configurations for the same host
+* Fixed issue where simp-tsds would fail while encoding JSON
+* Deprecated simp-poller "use_unix_socket" flag, now implied by the specification of a "unix_socket"
 
 ## 1.10.0 - Aug 22, 2022
 * Added IPv6 SNMP support to Poller

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME=simp
-VERSION=1.10.0
+VERSION=1.11.0
 
 .PHONY: dist
 

--- a/conf/poller/config.xsd
+++ b/conf/poller/config.xsd
@@ -16,14 +16,14 @@
 
     <!-- Required Child Elements -->
     <xsd:complexType name="REDIS_CONFIG">
-        <xsd:attribute name="ip"        type="IP_ADDR"     use="optional" />
-        <xsd:attribute name="port"      type="xsd:integer" use="optional" />
-        <xsd:attribute name="reconnect" type="xsd:integer" use="required" />
-	<xsd:attribute name="reconnect_every" type="xsd:integer" use="required" />
-	<xsd:attribute name="read_timeout"    type="xsd:integer" use="required" />
-	<xsd:attribute name="write_timeout"   type="xsd:integer" use="required" />
-	<xsd:attribute name="use_unix_socket"   type="xsd:integer" use="required" />
-	<xsd:attribute name="unix_socket"   type="xsd:string" use="optional" />
+        <xsd:attribute name="ip"              type="IP_ADDR"     use="optional" />
+        <xsd:attribute name="port"            type="xsd:integer" use="optional" />
+        <xsd:attribute name="reconnect"       type="xsd:integer" use="required" />
+        <xsd:attribute name="reconnect_every" type="xsd:integer" use="required" />
+        <xsd:attribute name="read_timeout"    type="xsd:integer" use="required" />
+        <xsd:attribute name="write_timeout"   type="xsd:integer" use="required" />
+        <xsd:attribute name="use_unix_socket" type="xsd:integer" use="optional" />
+        <xsd:attribute name="unix_socket"     type="xsd:string"  use="optional" />
     </xsd:complexType>
 
     <xsd:complexType name="PURGE_INTERVAL">

--- a/lib/GRNOC/Simp/Comp.pm
+++ b/lib/GRNOC/Simp/Comp.pm
@@ -15,7 +15,7 @@ use GRNOC::Config;
 use GRNOC::Log;
 use GRNOC::Simp::Comp::Worker;
 
-our $VERSION = '1.10.0';
+our $VERSION = '1.11.0';
 
 ### REQUIRED ATTRIBUTES ###
 

--- a/lib/GRNOC/Simp/Data.pm
+++ b/lib/GRNOC/Simp/Data.pm
@@ -13,7 +13,7 @@ use GRNOC::Config;
 use GRNOC::Log;
 use GRNOC::Simp::Data::Worker;
 
-our $VERSION = '1.10.0';
+our $VERSION = '1.11.0';
 
 =head2 public attributes
 =over 12

--- a/lib/GRNOC/Simp/Poller.pm
+++ b/lib/GRNOC/Simp/Poller.pm
@@ -533,7 +533,7 @@ sub _process_groups_config {
                 $info .= "$k = $v, ";             
             }
         }
-        $self->logger->info($info);
+        $self->logger->error($info);
     }
 
     # Set the number of forks and then the groups for the poller object
@@ -719,7 +719,7 @@ sub _balance_workers {
     # This prevents workers from spawning with no hosts that die instantly
     my $host_count = scalar(@{$self->hosts->{$group_name}});
     if ($host_count < $group->{workers}) {
-        $self->logger->info(sprintf(
+        $self->logger->error(sprintf(
             '%s has more workers than hosts, only %s of %s configured workers will be created',
             $group_name,
             $host_count,

--- a/lib/GRNOC/Simp/Poller.pm
+++ b/lib/GRNOC/Simp/Poller.pm
@@ -15,7 +15,7 @@ use GRNOC::Config;
 use GRNOC::Log;
 use GRNOC::Simp::Poller::Worker;
 
-our $VERSION = '1.10.0';
+our $VERSION = '1.11.0';
 
 ### Required Attributes ###
 =head2 public attributes

--- a/lib/GRNOC/Simp/Poller.pm
+++ b/lib/GRNOC/Simp/Poller.pm
@@ -88,6 +88,7 @@ has run_group => (
 =item logger
 =item hosts
 =item groups
+=item group_hosts
 =item total_workers
 =item status_path
 =item children
@@ -96,10 +97,11 @@ has run_group => (
 =back
 =cut
 
-has config => (is => 'rwp');
-has logger => (is => 'rwp');
-has hosts  => (is => 'rwp');
-has groups => (is => 'rwp');
+has config      => (is => 'rwp');
+has logger      => (is => 'rwp');
+has hosts       => (is => 'rwp');
+has groups      => (is => 'rwp');
+has group_hosts => (is => 'rwp');
 
 has total_workers => (
     is      => 'rwp',
@@ -141,31 +143,23 @@ sub BUILD {
     my $xsd = $self->validation_dir . 'config.xsd';
 
     # Validate the main config useing the xsd file for it
-    $self->_validate_config($self->config_file, $config, $xsd);
+    my $valid = $self->_validate_config($self->config_file, $config, $xsd);
+    exit(1) unless ($valid);
 
     # Set the config if it validated
     $self->_set_config($config);
     $self->logger->debug("Finished configuring the main Poller process");
 
     # Set status_dir to path in the configs, if defined and is a dir
-    $self->logger->debug("Setting up status writing for Poller");
     my $status_path = $self->config->get('/config/status');
     my $status_dir = $status_path ? $status_path->[0]->{dir} : undef;
-
     if (defined $status_dir && -d $status_dir) {
         if (substr($status_dir, -1) ne '/') {
             $status_dir .= '/';
-            $self->logger->debug("The path for status_dir didn't include a trailing slash, added it: $status_dir");
         }
-
         $self->_set_status_dir($status_dir);
-        $self->logger->debug("Found poller_status dir in config, using: " . $self->status_dir);
     }
-    else {
-        # Use default if not defined in configs, or invalid
-        $self->logger->debug("No valid poller_status dir defined in config, using: " . $self->status_dir);
-    }
-    $self->logger->debug("Finished setting up status writing for Poller");
+    $self->logger->debug("Set simp-poller status dir to " . $self->status_dir);
 
     return $self;
 }
@@ -186,44 +180,38 @@ sub _validate_config {
 
     # Use the validation code to log the outcome and exit if any errors occur
     if ($validation_code == 1) {
-        $self->logger->debug("Successfully validated $file");
+        $self->logger->debug("Validated $file");
         return 1;
     }
-    else {
-        if ($validation_code == 0) {
-            $self->logger->error("ERROR: Failed to validate $file!");
-            $self->logger->error($config->{error}->{error});
-            $self->logger->error($config->{error}->{backtrace});
-        }
-        else {
-            $self->logger->error("ERROR: XML schema in $xsd is invalid!\n" . $config->{error}->{backtrace});
-        }
-        exit(1);
+    elsif ($validation_code == 0) {
+        $self->logger->error("ERROR: Failed to validate $file!");
+        $self->logger->error($config->{error}->{error});
+        $self->logger->error($config->{error}->{backtrace});
     }
+    else {
+        $self->logger->error("ERROR: XML schema in $xsd is invalid!\n" . $config->{error}->{backtrace});
+    }
+    return;
 }
 
 
 =head2 _get_config_objects
-    Retrieves the XPath objects of a target from every XML file in a config dir.
-    Returns the objects in a hash reference.
+    Returns GRNOC::Config objects for every XML file in a dir.
+    Validates each XML file before instantiating the config object.
 =cut
 sub _get_config_objects {
     my $self       = shift;
-    my $target_obj = shift;
-    my $target_dir = shift;
-    my $xsd        = shift;
-
-    # The final hash of config objects to return
-    my %config_objects;
-
-    $self->logger->debug("Getting $target_obj XPath objects from $target_dir");
+    my $config_dir = shift;
+    my $config_xsd = shift;
 
     # Load all files in the target_dir into an array
-    opendir(my $dir, $target_dir);
+    opendir(my $dir, $config_dir);
     my @files = readdir $dir;
     closedir($dir);
+    $self->logger->debug("Config files found:\n" . Dumper(\@files));
 
-    $self->logger->debug("Files found:\n" . Dumper(\@files));
+    # Return this array of GRNOC::Config objects at the end
+    my @configs;
 
     # Check every file in the target dir
     for my $file (@files) {
@@ -233,150 +221,223 @@ sub _get_config_objects {
 
         # Make an XPath object from the file
         my $config = GRNOC::Config->new(
-            config_file => $target_dir . $file,
+            config_file => $config_dir . $file,
             force_array => 1
         );
 
         # Validate the config using the main config xsd file
-        $self->_validate_config($file, $config, $xsd);
-
-        # Push each targeted XPath object found in the file into the final array
-        for my $object (@{$config->get($target_obj)}) {
-
-            # Check if the object has been set to inactive
-            unless ($object->{active} and $object->{active} == 0) {
-
-                # Use the object name as the key to the object
-                if (exists $object->{name}) {
-                    # Check for a group key and for pre-existing configs; for merging multiple host configs.
-                    if (exists $object->{group} && exists $config_objects{$object->{name}}) {
-                        $config_objects{$object->{name}}->{group} = {%{$config_objects{$object->{name}}->{group}}, %{$object->{group}}};
-                    }
-                    else {
-                        $config_objects{$object->{name}} = $object;
-                    }
-                    delete $object->{name};
-                }
-                # Use the config file name as the key to the object
-                else {
-                    $config_objects{substr($file, 0, -4)} = $object;
-                }
-            }
-            else {
-                $self->logger->debug('Skipping inactive object');
-            }
+        my $valid = $self->_validate_config($file, $config, $config_xsd);
+        
+        if ($valid) {
+            push(@configs, {file => $file, config => $config});
+        }
+        else {
+            $self->logger->error("ERROR: $file is invalid and will be ignored.");
         }
     }
-
-    $self->logger->debug("Got a total of " . scalar(keys %config_objects) . " $target_obj objects");
-    return \%config_objects;
+    return \@configs;
 }
 
 
-=head2 _process_hosts_config
-    Process the host configs for their polling groups.
-    Create and remove status dirs based upon which hosts are found.
-    Set the hosts for the poller objects.
+=head2 _make_status_dir
+    Initializes the status dir for a host if it does not exist.
 =cut
-sub _process_hosts_config {
+sub _make_status_dir {
     my $self = shift;
+    my $host = shift;
+    my $host_dir = $self->status_dir . $host->{name} . '/';
 
-    # Get the hosts from the hosts.d file
-    my $hosts = $self->_get_config_objects(
-        '/config/host', 
-        $self->hosts_dir, 
-        $self->validation_dir . 'hosts.xsd'
-    );
-
-    # Process each host in the config
-    while (my ($host_name, $host_attr) = each(%$hosts)) {
-
-        # Parse the SNMP version (default is V2)
-        my $snmp_version = ($host_attr->{snmp_version} =~ m/.*([123]).*/) ? $1 : '2';
-        $host_attr->{snmp_version} = $snmp_version;
-
-        $self->logger->error("Could not determine SNMP version for $host_name") unless ($snmp_version);
-
-        # Infer transport domain from IP format; assume IPv4, otherwise IPv6. IP already regex validated by hosts.xsd in validation.d.
-        $host_attr->{transport_domain} = $host_attr->{ip} =~ m/^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/ ? 'udp4' : 'udp6';
-
-        # Parse and set the ports for each polling group the host belongs to
-        # Group ports will override host-wide ports
-        # If no ports are specified, Net::SNMP will default to port 161
-        my $host_ports = $self->_parse_ports($host_attr->{ports}) if (exists($host_attr->{ports}));
-
-        while (my ($group_name, $group_attr) = each(%{$host_attr->{group}})) {
-
-            # Reference to the ports that should be used for the group
-            my $ports;
-
-            # Set ports using the group-specific ports
-            if (exists($group_attr->{ports})) {
-                $ports = $self->_parse_ports($group_attr->{ports});
-            }
-            # Set ports using the host-wide ports
-            elsif ($host_ports) {
-                $ports = $host_ports;
-            }
-            # Default to port 161 only
-            else {
-                $ports = ['161'];
-            }
-            $group_attr->{ports} = $ports; 
-
-        }
-
-        # Check if status dir for each host exists, or create it.
-        my $mon_dir = $self->status_dir . $host_name . '/';
-        unless (-e $mon_dir || system("mkdir -m 0755 -p $mon_dir") == 0) {
-            $self->logger->error("Could not find or create dir for monitoring data: $mon_dir");
-        }
-        else {
-            $self->logger->debug("Found or created status dir for $host_name successfully");
-        }
+    unless (-e $host_dir || system("mkdir -m 0755 -p $host_dir") == 0) {
+        $self->logger->error("Could not find or create dir for monitoring data: $host_dir");
     }
+}
+
+
+=head2
+    Cleans up old host dirs and status files.
+    This should be run after new host configs are processed.
+=cut
+sub _refresh_status_dirs {
+    my $self  = shift;
+
+    $self->logger->info("Refreshing simp-poller status files");
 
     # Once status dirs for configured hosts have been made...
-    # Remove any dirs for hosts that are not included in any hosts.d file
-    # Remove any status files in a valid host dir for groups
-    # the host doesn't have configured
-    for my $host_dir (glob($self->status_dir . '*')) {
-        my $dir_name = (split(/\//, $host_dir))[-1];
+    # Remove any dirs for hosts that are not included in a hosts.d file
+    # Remove status files for groups a host doesn't have configured
+    for my $path (glob($self->status_dir . '*')) {
 
-        # Remove the dir unless the dir name exists in the hosts hash
-        unless (exists $hosts->{$dir_name}) {
-            $self->logger->debug("$host_dir was flagged for removal");
+        # Get the intended host name from the dir name
+        my $dir_host = (split(/\//, $path))[-1];
 
-            # This needs constraints, but works as is
-            unless (rmtree([$host_dir])) {
-                $self->logger->error("Attempted to remove $host_dir, but failed!");
-            }
-            else {
-                $self->logger->debug("Successfully removed $host_dir");
+        # Validate if the host exists in any group
+        my $valid = 0;
+
+        while (my ($group_name, $hosts) = each(%{$self->group_hosts})) {
+            if (exists($hosts->{$dir_host})) {
+                $valid++;
+                last;
             }
         }
+        
+        # If the host was invalidated, remove its dir and skip to next host
+        unless ($valid) {
+            unless (rmtree[$path]) {
+                $self->logger->error("ERROR: Attempt to remove $path failed!");
+            }
+            else {
+                $self->logger->debug("Removed $path");
+            }
+            next;
+        }
 
-        # When the dir exists, clean it up so only active groups are present
-        else {
-            for my $status_file (glob($host_dir . '/*')) {
+        
+        # If valid, clean up group files that are no longer configured
+        for my $status_file (glob($path . '/*')) {
 
-                # Get the filename
-                my $file = (split(/\//, $status_file))[-1];
+            # Get the filename
+            my $group_file = (split(/\//, $status_file))[-1];
 
-                # Get the polling group's name
-                $file =~ /^(.+)_status\.json$/;
+            # Get the polling group's name
+            $group_file =~ /^(.+)_status\.json$/;
 
-                # Unless the host is configured for the group, delete the status file
-                unless (exists $hosts->{$dir_name}{group}{$1}) {
-                    unlink $status_file;
-                    $self->logger->debug("Removed status file $file in $host_dir");
+            # Unless the host is configured for the group, delete the status file
+            unless (exists($self->group_hosts->{$1}{$dir_host})) {
+                unlink $status_file;
+                $self->logger->debug("Removed $path/$group_file");
+            }
+        }
+    }
+}
+
+
+=head2 _process_host_configs
+    Process the host configs to use for polling groups.
+    Create and remove hosts' status dirs based upon which hosts are found.
+=cut
+sub _process_host_configs {
+    my $self = shift;
+
+    $self->logger->debug(sprintf("Reading host configs in %s", $self->hosts_dir));
+
+    # Hash of group names mapped to an array of their hosts' configs
+    # Organized like: {group_name => [{host configuration}]}
+    my %hosts;
+
+    # Hash of group names mapped to a hash of host names for the group
+    # Used for quickly checking which hosts are in which groups.
+    my %group_hosts;
+
+    # Tracking metrics for unique hosts and total polling configs
+    my %host_metrics;
+
+    # Get the valid GRNOC::Config objects from each hosts.d file
+    my $hosts_dir     = $self->hosts_dir;
+    my $hosts_xsd     = $self->validation_dir . 'hosts.xsd';
+    my $hosts_objects = $self->_get_config_objects($hosts_dir, $hosts_xsd);
+
+    # Process each hosts config object
+    for my $hosts_object (@$hosts_objects) {
+
+        my $file   = $hosts_object->{file};
+        my $config = $hosts_object->{config};
+
+        $self->logger->debug(sprintf("Processing hosts from %s", $file));
+
+        # Process each host definition in the file
+        for my $host (@{$config->get('/config/host')}) {
+
+            # Create a status dir for the host
+            # NOTE: This MUST occur before the host's "group" KVP is deleted
+            $self->_make_status_dir($host);
+
+            # Initialize a hash for tracking status data for this host config
+            # It is used by the worker to track status and write monitoring files
+            $host->{status} = {
+                snmp_errors     => [],
+                failed_oids     => [],
+                pending_replies => {},
+            };
+
+            # Tracks pending SNMP requests for oids.
+            # Used by workers to determine if a response has been received
+            $host->{pending_replies} = {};
+
+            # SNMP version (default is V2)
+            my $snmp_version = ($host->{snmp_version} =~ m/.*([123]).*/) ? $1 : '2';
+            $host->{snmp_version} = $snmp_version;
+
+            # Get transport domain from IP format.
+            # Assume IPv4, otherwise IPv6.
+            # IP already regex validated by XSD.
+            my $transport = $host->{ip} =~ m/^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/ ? 'udp4' : 'udp6';
+            $host->{transport_domain} = $transport;
+
+            # Get the ports the host should use.
+            # If the host has ports set for a group, those will be applied in the group loop.
+            my $host_ports = $self->_parse_ports($host);
+
+            # Copy the groups and group-level configs before deleting from the host
+            # Group configs are applied to copies of the master host config hash.
+            my $groups = {%{$host->{group}}};
+            delete $host->{group};
+
+            # Add the host config for each group
+            while (my ($group_name, $group) = each(%$groups)) {
+
+                # Initialize the group's host array if needed
+                $hosts{$group_name} = [] unless (exists($hosts{$group_name}));
+
+                # Initialize the group_hosts mapping if needed
+                $group_hosts{$group_name} = () unless (exists($group_hosts{$group_name}));
+
+                # Track the hostname for the group
+                $group_hosts{$group_name}{$host->{name}} = 1;
+                
+                # Get the ports used specifically for this group
+                my $group_ports = $self->_parse_ports($group);
+
+                # Determine whether to use host-defined or group-defined ports
+                my $ports = ($group_ports) ? $group_ports : $host_ports;
+
+                # Create a host config for each port that needs to be polled
+                for my $port (@$ports) {                
+
+                    # Copy the initial host config
+                    my $host_copy = {%$host};
+
+                    # Set the port and remove the array of ports in the copy
+                    $host_copy->{port} = $port;
+                    delete $host_copy->{ports};
+
+                    # Check for SNMPv3 ContextEngineIDs for the group
+                    # Duplicate the host config for each context
+                    if (exists($group->{context_id})) {
+                        for my $context (@{$group->{context_id}}) {
+                            
+                            # Create another copy of the host config hash
+                            my $host_context_copy = {%$host_copy};            
+
+                            # Add the context ID
+                            $host_context_copy->{context} = $context;           
+ 
+                            # Push the host config
+                            push(@{$hosts{$group_name}}, $host_context_copy);            
+                        }
+                    }
+                    # If no context IDs exist, push the host config
+                    else {
+                        push(@{$hosts{$group_name}}, $host_copy);
+                    }
                 }
             }
         }
+        $self->logger->debug(sprintf("Finished processing hosts from %s", $file));
     }
 
-    $self->_set_hosts($hosts);
-    $self->logger->debug("Finished processing host configurations");
+    $self->_set_hosts(\%hosts);
+    $self->_set_group_hosts(\%group_hosts);
+    $self->logger->info("Finished processing all host configurations");
 }
 
 
@@ -387,103 +448,96 @@ sub _process_hosts_config {
 sub _process_groups_config {
     my $self = shift;
 
+    # Final hash of group configs by name
+    my %groups;
+
+    $self->logger->debug(sprintf("Reading group configs in %s", $self->groups_dir));
+
+    # Get the valid GRNOC::Config objects from each groups.d file
+    my $groups_dir    = $self->groups_dir;
+    my $groups_xsd    = $self->validation_dir . 'group.xsd';
+    my $group_objects = $self->_get_config_objects($groups_dir, $groups_xsd);
+
     # Get the default results-per-request size (max_repetitions)
     # from the poller config. (Default to 15)
     my $request_size = $self->config->get('/config/request_size');
     my $num_results = $request_size ? $request_size->[0]->{results} : 15;
 
-    # Get the group objects from the files in groups.d
-    my $groups = $self->_get_config_objects(
-        '/group', 
-        $self->groups_dir, 
-        $self->validation_dir . 'group.xsd'
-    );
-
     # Get the total number of workers to fork and
     # set the group name and any defaults
     my $total_workers = 0;
 
-    while (my ($group_name, $group_attr) = each(%$groups)) {
+    for my $group_object (@$group_objects) {   
+ 
+        my $file  = $group_object->{file};
+        my $group = $group_object->{config}->get('/group')->[0];
+
+        $self->logger->debug("Processing group defined in $file");
+
+        # Parse the group name from the file name
+        my $name = substr($file, 0, -4);
+
+        # Ensure there are configured hosts for the group
+        # Don't configure this group if it has no configured hosts
+        unless (exists($self->hosts->{$name}) && $self->hosts->{$name}) {
+            $self->logger->info("No hosts configured for $name, skipping it");
+            next;
+        }
 
         # Set the oids for the group from the mib elements
         # Then, remove the mib attr to prevent redundant data under a confusing name
-        $group_attr->{oids} = [];
-        for my $oid (@{$group_attr->{mib}}) {
-            push (@{$group_attr->{oids}}, $oid);
-        }
-        delete $group_attr->{mib};
+        $group->{oids} = [@{$group->{mib}}];
+        delete $group->{mib};
 
-        $self->logger->debug("Optional settings for group $group_name");
-
-        # Set retention time to 5x the polling interval
-        unless ($group_attr->{retention}) {
-            $group_attr->{retention} = $group_attr->{interval} * 5;
-            $self->logger->debug("Retention Period: $group_attr->{retention} (default)");
+        # Set default retention time to 5x the polling interval
+        unless ($group->{retention}) {
+            $group->{retention} = $group->{interval} * 5;
         }
-        else {
-            $self->logger->debug("Retention Period: $group_attr->{retention} (specified)");
-        }
+        $self->logger->debug("Set retention period to $group->{retention}s");
 
         # Set the packet results size (max_repetitions) or default to size from poller config
-        unless ($group_attr->{request_size}) {
-            $group_attr->{request_size} = $num_results;
-            $self->logger->debug("Request Size: $group_attr->{request_size} results (default)");
+        unless ($group->{request_size}) {
+            $group->{request_size} = $num_results;
         }
-        else {
-            $self->logger->debug("Request Size: $group_attr->{request_size} results (specified)");
-        }
+        $self->logger->debug("Set request size to $group->{request_size} results");
 
-        # Set the hosts that belong to the polling group
-        $group_attr->{hosts} = ();
-        while (my ($host_name, $host_attr) = each(%{$self->hosts})) {
+        # Get the array of host configs for the group
+        my $hosts = $self->hosts->{$name};
 
-            # Skip any hosts that don't belong to the group
-            next unless (exists($host_attr->{group}{$group_name}));
+        # Set total host and session counts needed
+        $group->{unique_hosts} = scalar(keys(%{$self->group_hosts->{$name}}));
+        $group->{snmp_sessions} = scalar(@{$self->hosts->{$name}});
 
-            # Create a reference to any host-specific group parameters (ports, contexts)
-            my $host_specific = $host_attr->{group}{$group_name};
-
-            # Build a host object having the host's parameters for the group config
-            my %host_obj = %$host_attr;
-            
-            # Put the hostname in the object
-            $host_obj{name} = $host_name;
-
-            # Get the ports needed for the polling group for this host
-            $host_obj{ports} = $host_specific->{ports};
-
-            # Initialize an error cache for the host
-            $host_obj{errors} = {};
-
-            # Add the count of sessions for the host to determine the load it has on the worker
-            # This will be N sessions per port and N*M sessions for port+context combos
-            my $host_load = scalar(@{$host_obj{ports}});
-
-            # Get any context ID's for the group and factor in their effect on load
-            if (exists($host_specific->{context_id})) {
-                $host_obj{contexts} = $host_specific->{context_id};
-                $host_load *= scalar(@{$host_obj{contexts}});
-            }
-        
-            # Set the calculated load for this host
-            $host_obj{load} = $host_load;
-
-            # Remove the 'group' hash from the host object, the worker doesn't need it
-            delete $host_obj{group};
-
-            # Add the host object to the group's hosts array
-            push(@{$group_attr->{hosts}}, \%host_obj);
-        }
+        # Determine the load of the hosts configured for the group
+        # Load represents the total requests per second of each worker for the group
+        # Load = ((Hosts * OIDs) / Interval) / Workers
+        $group->{load} = (scalar(@$hosts) * scalar(@{$group->{oids}})) / $group->{workers};
 
         # Add the groups' workers to the total number of forks to create
-        $total_workers += $group_attr->{workers};
+        $total_workers += $group->{workers};
+
+        # Set the group config
+        $groups{$name} = $group;
+   
+        my $info = "Configured $name: ";
+        while (my ($k, $v) = each(%$group)) {
+            if ($k eq 'oids') {
+                $info .= sprintf("%s %s, ", scalar(@$v), $k);
+            }
+            elsif ($k eq 'load') {
+                $info .= sprintf("%s avg worker requests per second, ", $v);
+            }
+            else {
+                $info .= "$k = $v, ";             
+            }
+        }
+        $self->logger->info($info);
     }
 
     # Set the number of forks and then the groups for the poller object
     $self->_set_total_workers($total_workers);
-    $self->_set_groups($groups);
-
-    $self->logger->debug('Finished processing group configurations');
+    $self->_set_groups(\%groups);
+    $self->logger->info('Finished processing all group configurations');
 }
 
 =head2 start
@@ -499,7 +553,6 @@ sub start {
 
         # Set the PID file from config or use the default
         my $pid_file = $self->config->get('/config/@pid-file')->[0] || '/var/run/simp_poller.pid';
-        $self->logger->debug("PID FILE: " . $pid_file);
 
         # Create the main Poller daemon using our PID and initialize it
         my $daemon = Proc::Daemon->new(pid_file => $pid_file);
@@ -556,13 +609,9 @@ sub start {
     # Parse configs and create workers from within the reload loop
     # When reloaded, hosts.d and groups.d will be re-parsed
     while (1) {
-        $self->logger->info("Processing host configurations");
-        $self->_process_hosts_config();
-
-        $self->logger->info("Processing group configurations");
+        $self->_process_host_configs();
         $self->_process_groups_config();
-
-        $self->logger->info("Creating worker processes");
+        $self->_refresh_status_dirs();
         $self->_create_workers();
 
         # We only arrive here if the loop is running or poller is killed
@@ -581,14 +630,19 @@ sub start {
     Returns an arrayref of the port numbers from the string
 =cut
 sub _parse_ports {
-    my $self     = shift;
-    my $port_str = shift;
+    my $self = shift;
+    my $host = shift;
+
+    my $port_str = $host->{ports};
+    
+    # Return only the default port if no definitions are found
+    return ['161'] unless (exists $host->{ports});
 
     # An array of port numbers to return
     my @ports;
 
     # Get the array of port specifications from CSV string
-    my @csv_array = split(/ ?, ?/, $port_str);
+    my @csv_array = split(/ ?, ?/, $host->{ports});
 
     for (my $i = 0; $i <= $#csv_array; $i++) {
         
@@ -641,12 +695,68 @@ sub stop {
 
     my @pids = @{$self->children};
 
-    $self->logger->debug('Stopping child worker processes ' . join(' ', @pids) . '.');
+    $self->logger->info('Stopping child worker processes ' . join(' ', @pids) . '.');
 
     # Kill children, then wait for them to finish exiting
     my $res = kill('TERM', @pids);
 }
 
+
+=head2 _balance_workers
+    Creates a configuration of hosts per worker given a group.
+    Balances the polling load evenly between a group's workers.
+=cut 
+sub _balance_workers {
+    my $self       = shift;
+    my $group_name = shift;
+    my $group      = shift;
+    
+    $self->logger->debug("Balancing host load across $group->{workers} $group_name workers");
+
+    # Get the worker IDs, and track their load and assigned host configs
+    my @workers = map {[]} (0 .. ($group->{workers} - 1));
+
+    # Tracks the worker ID we should be adding a host to
+    # and the worker ID all configs for a single hostname should belong to
+    my $id = 0;
+
+    # Map hostname to a worker ID/index
+    # all configs of the same hostame+group are added to the same worker.
+    my %host_map;
+
+    # Assign hosts to workers while balancing the load of each worker
+    for my $host (@{$self->hosts->{$group_name}}) {
+
+        # Track the least-loaded worker's index
+        # Init the minimum load as MAX_INT
+        my $min_load = ~0;
+
+        # Bypass load balancing for hosts that have already been added to a worker
+        # Push them to the same worker instead
+        if (exists($host_map{$host->{name}})) {
+            push(@{$workers[$host_map{$host->{name}}]}, $host);
+            next;
+        }
+
+        # Track the smallest load and assign the host to that worker
+        # Minimum load initialized to MAX_INT
+        my $min = ~0;
+        for (my $i = 0; $i <= $#workers; $i++) {
+            my $load = scalar(@{$workers[$i]});
+            if ($min > $load) {
+                $min = $load;
+                $id = $i;
+            }
+        }
+
+        # Add the host to the worker's host array
+        push(@{$workers[$id]}, $host);
+        
+        # Track which worker the hostname belongs to
+        $host_map{$host->{name}} = $id unless(exists($host_map{$host->{name}}));
+    }
+    return \@workers;
+}
 
 =head2 _create_workers
     Creates the forked worker processes for each polling group.
@@ -658,60 +768,9 @@ sub _create_workers {
     # Create a fork for each worker that is needed
     my $forker = Parallel::ForkManager->new($self->total_workers);
 
-    # Create workers for each group
-    while (my ($group_name, $group_attr) = each(%{$self->groups})) {
+    while (my ($group_name, $group) = each(%{$self->groups})) {
 
-        # Get the range of worker IDs in an array
-        my @worker_ids = map {$_} (0 .. ($group_attr->{workers} - 1));
-
-        # Track the session load a worker has been assigned
-        my %worker_loads = map {$_ => 0} @worker_ids;
-
-        # Track which hosts have been assigned to which worker
-        my %worker_hosts = map {$_, []} @worker_ids;
-
-        # Track the worker ID we should be adding a host to
-        my $worker_id = 0;
-
-        # Add hosts to workers and load balance them based upon the load of hosts the worker has
-        for my $host_obj (@{$group_attr->{hosts}}) {            
-
-            # Add at least one host to each worker before load balancing
-            if ($worker_loads{$worker_id} == 0) {
-
-                # Add the host and it's load to our tracking hashes
-                push(@{$worker_hosts{$worker_id}}, $host_obj);
-                $worker_loads{$worker_id} += $host_obj->{load};
-
-                # Increment the worker ID until each worker has a host, then set back to 0
-                $worker_id = ($worker_id >= $#worker_ids) ? 0 : $worker_id + 1;
-
-                # Skip to the next host
-                next;
-            }
-
-            # Determine least-loaded worker if the current worker already has a load
-            # Init the minimum load as the first worker's load
-            my $min_load = ~0 ;
-
-            # Check each worker's current load
-            while (my ($id, $load) = each(%worker_loads)) {
-
-                # Switch the worker ID and min load to the new worker if it has less load
-                if ($min_load > $load) {
-                    $min_load  = $load;
-                    $worker_id = $id;
-                }
-            }
-
-            # Add the worker and it's load to our tracking hashes
-            push(@{$worker_hosts{$worker_id}}, $host_obj);
-            $worker_loads{$worker_id} += $host_obj->{load};
-        }
-
-        $self->logger->info("Creating $group_attr->{workers} worker processes for $group_name");
-
-        # Keep track of children pids
+        # Tells worker procs to log a message when they die
         $forker->run_on_finish(
             sub {
                 my ($pid) = @_;
@@ -719,48 +778,61 @@ sub _create_workers {
             }
         );
 
-        # Create workers
-        for (my $worker_id = 0; $worker_id < $group_attr->{workers}; $worker_id++) {
+        # Get an array of load-balanced host arrays where index is the worker_id
+        my $workers = $self->_balance_workers($group_name, $group);
 
+        # Create workers using the load-balanced worker configuration
+        for (my $worker_id = 0; $worker_id <= $#$workers; $worker_id++) {
+
+            # Get the array of hosts for the worker ID
+            my $hosts = $workers->[$worker_id];
+
+            # Jump into the worker process
             my $pid = $forker->start();
 
-            # We're still in the parent if so
+            # PID == True for the parent process, but not the worker process
             if ($pid) {
-                $self->logger->debug(sprintf("PID %s created for %s [%s]", $pid, $group_name, $worker_id));
+                my $msg = sprintf(
+                    "%s [%s] (PID %s) created for %s host configurations",
+                    $group_name,
+                    $worker_id,
+                    $pid,
+                    scalar(@$hosts)
+                );
+                $self->logger->info($msg);
                 push(@{$self->children}, $pid);
+
+                # Parent process continues loop without running the rest of its code
                 next;
             }
 
-            # Create worker in this process
+            # Create the worker within the forked process
             my $worker = GRNOC::Simp::Poller::Worker->new(
                 instance     => $worker_id,
                 config       => $self->config,
                 logger       => $self->logger,
                 status_dir   => $self->status_dir,
                 group_name   => $group_name,
-                oids         => $group_attr->{oids},
-                interval     => $group_attr->{interval},
-                retention    => $group_attr->{retention},
-                request_size => $group_attr->{request_size},
-                timeout      => $group_attr->{timeout},
-                hosts        => $worker_hosts{$worker_id} || {}
+                oids         => $group->{oids},
+                interval     => $group->{interval},
+                retention    => $group->{retention},
+                request_size => $group->{request_size},
+                timeout      => $group->{timeout},
+                hosts        => $hosts || []
             );
 
-            # This should only return when the worker has stopped (TERM, No hosts, etc)
+            # Worker's start method should only return when it has stopped (TERM, No hosts, etc)
             $worker->start();
 
-            # Exit child process
+            # Exit the worker process if it has died
             $forker->finish();
         }
     }
-
-    $self->logger->info('Waiting for all child worker processes to exit.');
-
+    
+    $self->logger->info('simp-poller startup complete');
     $forker->wait_all_children();
-
     $self->_set_children([]);
-
-    $self->logger->info('All child workers have exited.');
+    $self->logger->info('All workers have died');
 }
 
 1;

--- a/lib/GRNOC/Simp/Poller/Worker.pm
+++ b/lib/GRNOC/Simp/Poller/Worker.pm
@@ -77,6 +77,7 @@ has interval => (
 =item timeout
 =item main_cv
 =item first_run
+=item status_data
 
 =back
 =cut
@@ -111,6 +112,10 @@ has main_cv => (is => 'rwp');
 has first_run => (
     is      => 'rwp',
     default => 1
+);
+has status_data => (
+    is => 'rwp',
+    default => sub{{}}
 );
 
 ### Public Methods ###
@@ -265,29 +270,31 @@ sub _poll_cb {
     my %params = @_;
 
     # Set the arguments for the callback
-    my $session = $params{session};
+    my $host    = $params{host};
     my $time    = $params{time};
-    my $name    = $params{name};
-    my $ip      = $params{ip};
     my $oid     = $params{oid};
-    my $reqstr  = $params{reqstr};
-    my $vars    = $params{vars};
+
+    # Get params from the host object
+    my $name         = $host->{name};
+    my $ip           = $host->{ip};
+    my $port         = $host->{port};
+    my $context      = $host->{context};
+    my $status       = $host->{status};
+    my $vars         = $host->{host_variable};
 
     # Get some variables from the worker
     my $redis    = $self->redis;
     my $group    = $self->group_name;
     my $worker   = $self->worker_name;
 
-    # Get a reference to the SNMP session, port, and context
-    my $snmp    = $session->{session};
-    my $port    = $session->{port};
-    my $context = $session->{context};
+    # Get a reference to the SNMP session
+    my $snmp = $host->{snmp_session};
 
     # Get, find, or initialize the session's poll_id
     my $poll_id;
     my $poll_time;
-    if (exists($session->{poll_id})) {
-        $poll_id = $session->{poll_id};
+    if (exists($status->{poll_id})) {
+        $poll_id = $status->{poll_id};
     }
     else {
         # Get the current poll ID for the host from Redis
@@ -317,7 +324,7 @@ sub _poll_cb {
         }
 
         # Set the poll_id for the session
-        $session->{poll_id} = $poll_id;
+        $status->{poll_id} = $poll_id;
     }
 
     $self->logger->debug(sprintf("%s - _poll_cb processing %s:%s %s", $worker, $name, $port, $oid));
@@ -325,7 +332,7 @@ sub _poll_cb {
     # Reset the session's pending reply status for the OID
     # This advances pending replies even if we didn't get anything back for the OID
     # We do this because the polling cycle has completed in both cases
-    delete $session->{'pending_replies'}{$oid};
+    delete $status->{pending_replies}{$oid};
 
     # Get the data returned by the session's SNMP request
     my $data = $snmp->var_bind_list();
@@ -335,16 +342,16 @@ sub _poll_cb {
 
     # Handle errors where there was no value data for the OID 
     unless (@values) {
-        $session->{failed_oids}{"$oid:$port"} = {
-            error     => "OID_DATA_ERROR",
-            timestamp => time()
+        my $error_data = {
+            oid         => $oid,
+            error       => 'OID_DATA_ERROR',
+            description => $snmp->error(),
+            timestamp   => time()
         };
+        push(@{$status->{failed_oids}}, $error_data);
 
-        # Add the context to the hash of failed OIDs for the session
-        $session->{failed_oids}{$oid}{context} = $context if (defined($context));
-
-        my $error = "%s - ERROR: %s failed to request %s: %s"; 
-        $self->logger->error(sprintf($error, $worker, $name, $reqstr, $snmp->error()));
+        my $error = "%s - ERROR: No data returned from %s:%s for %s: %s";
+        $self->logger->error(sprintf($error, $worker, $name, $port, $oid, $snmp->error()));
     }
 
     # Calculate when this key should expire based on NOW when the response
@@ -399,7 +406,7 @@ sub _poll_cb {
         $redis->sadd($host_keys{db0}, @values, sub{}) if (@values);
 
         # Check that the session has no pending replies left
-        if (scalar(keys(%{$session->{'pending_replies'}})) == 0) {
+        if (keys($status->{pending_replies})) {
 
             # Set the expiration time for the master key once all replies are received
             $redis->expire($host_keys{db0}, $expire, sub{});
@@ -437,8 +444,8 @@ sub _poll_cb {
                 $redis->hset($ip_id,   "vars", $group_interval, sub{});
             }
 
-            # Increment the session's poll_id
-            $session->{poll_id}++;
+            # Increment the poll_id
+            $status->{poll_id}++;
         }
 
         # Set an OID lookup using vars and interval for the OIDs
@@ -453,6 +460,9 @@ sub _poll_cb {
     # Ensure we're done with the pipeline
     $redis->wait_all_responses();
 
+    # Update the global status for this host
+    $self->_update_status($host);
+
     # Update the AnyEvent pipeline
     AnyEvent->now_update;
 }
@@ -465,6 +475,7 @@ sub _get_session_args {
     my %session_args = (
         -hostname    => $host->{ip},
         -version     => $host->{snmp_version},
+        -port        => $host->{port},
         -domain      => $host->{transport_domain},
         -nonblocking => 1,
         -retries     => 5,
@@ -485,26 +496,12 @@ sub _get_session_args {
         '-privprotocol' => 'priv_protocol'
     );
 
-    # Stores every set of session args needed for the host
-    my @sessions;
-
-    # Create a new set of session args for each port
-    for my $port (@{$host->{ports}}) {
-        
-        # Copy the session args for each port
-        my %session = %session_args;
-
-        # Add each optional arg for the session if it's specified
-        while (my ($arg, $attr) = each(%optional_args)) {
-            $session{$arg} = $host->{$attr} if (exists($host->{$attr}) && defined($host->{$attr}));
-        }
-
-        # Add the port to the session args
-        $session{'-port'} = $port;
-
-        push(@sessions, \%session);
+    # Add each optional arg for the session if it's specified
+    while (my ($arg, $attr) = each(%optional_args)) {
+        $session_args{$arg} = $host->{$attr} if (exists($host->{$attr}) && defined($host->{$attr}));
     }
-    return \@sessions;
+
+    return \%session_args;
 }
 
 
@@ -515,160 +512,154 @@ sub _get_session_args {
 sub _connect_to_snmp {
     my $self  = shift;
 
-    for my $host_attr (@{$self->hosts}) {
+    for my $host (@{$self->hosts}) {
 
-        # We will store our SNMP session objects in here for the host
-        $host_attr->{sessions} = [];
+        $self->logger->debug(sprintf(
+            "%s - Creating SNMP session for %s:%s",
+            $self->worker_name,
+            $host->{name},
+            $host->{port}
+        ));
 
-        # Get the hostname, SNMP version, array of session args, and failed session tracker
-        my $host_name    = $host_attr->{name};
-        my $context_ids  = $host_attr->{contexts};
-        my $version      = $host_attr->{snmp_version};
-        my $session_args = $self->_get_session_args($host_attr);
-        my $failed       = 0;
+        # Get the SNMP version, host status, and hash of session args
+        my $version   = $host->{snmp_version};
+        my $status    = $host->{status};
+        my $args      = $self->_get_session_args($host);
 
-        # Create the session data hashes for each session
-        # Apply the session args that were generated, multiplying by context IDs
-        # If we don't have any contexts, pretend we do to avoid duplicate code
-        for my $args (@$session_args) {
+        # Report when there's no community specified and we have V1 or V2
+        if ($version < 3 && !defined($args->{'-community'})) {
+            my $error = sprintf("%s - SNMPv1 or v2 with no community set for %s!", $self->worker_name, $host->{name});
+            my $error_data = {
+                type        => 'community',
+                description => $error,
+                error       => $error,
+                timestamp   => time()
+            };
+            push(@{$status->{snmp_errors}}, $error_data);
+            $self->logger->error($error);
+        }
 
-            $self->logger->debug(sprintf("%s - Creating session for %s:%s", $self->worker_name, $host_name, $args->{'-port'}));
+        # Create the SNMP session
+        my ($session, $session_error) = Net::SNMP->session(%$args);
 
-            # This will allow the next loop to run when there are not context IDs
-            my $total_contexts = exists($host_attr->{contexts}) ? scalar(@{$host_attr->{contexts}}) : 1;
+        # Keep the SNMP session object with the host config
+        $host->{snmp_session} = $session;
 
-            for (my $i = 0; $i < $total_contexts; $i++ ) {
+        # Report errors that occurred while creating the SNMP session
+        if (!$session || $session_error) {
+            my $cid = exists($host->{context}) ? $host->{context} : 'N/A';
+            my $error = sprintf(
+                "%s - Error while creating SNMPv%s session for %s:%s (ContextID: %s): %s",
+                $self->worker_name,
+                $version,
+                $host->{name},
+                $host->{port},
+                $cid,
+                $session_error
+            );
+            $self->logger->error($error);
 
-                my $context_id = $context_ids->[$i];
-
-                # We store the SNMP session, poll_id, port, context, and error data in this hash
-                # Note: A poll_id will be set later during the first polling cycle in poll_cb().
-                my %session_data = (
-                    session         => 0,
-                    port            => $args->{'-port'},
-                    errors          => {},
-                    failed_oids     => {},
-                    pending_replies => {},
-                ); 
-                $session_data{context} = $context_id if (defined($context_id));
-        
-                # Send an error when there's no community specified and we have V1 or V2
-                if ($version < 3 && !defined($args->{'-community'})) {
-                    $self->logger->error("SNMP is v1 or v2, but no community is defined for $host_name!");
-                    $session_data{errors}{community} = {
-                        time  => time,
-                        error => "No community was defined for $host_name:"
-                    };
-                }
-
-                # Connect the SNMP session and add it to the session hash
-                my ($snmp_session, $session_error) = Net::SNMP->session(%$args);
-                $session_data{session} = $snmp_session;
-            
-                # Add the session hash to the host's sessions array
-                push(@{$host_attr->{sessions}}, \%session_data);
-
-                # Check for errors creating the SNMP session
-                if (!$snmp_session || $session_error) {
-
-                    my $err_str = "%s - Error while creating SNMPv%s session with %s:%s (ContextID: %s): %s";
-                    my $cid_str = exists($session_data{context}) ? $session_data{context} : 'N/A';
-
-                    my $error = sprintf(
-                        $err_str,
-                        $self->worker_name,
-                        $version,
-                        $host_name,
-                        $session_data{port},
-                        $cid_str,
-                        $session_error
-                    );
-
-                    $self->logger->error($error);
-            
-                    $session_data{errors}{session} = {
-                        time  => time,
-                        error => $error
-                    };
-                }
-            }
+            my $error_data = {
+                type        => 'session', 
+                description => $error,
+                error       => $error,
+                timestamp   => time()
+            };
+            push(@{$status->{snmp_errors}}, $error_data);
         }
     }
 }
 
 
-sub _write_mon_data {
+sub _update_status {
     my $self = shift;
     my $host = shift;
-    my $name = shift;
 
-    # Skip writing if it's the worker's first poll cycle
-    # to avoid clearing active alarm status'
+    my $failed_oids = $host->{status}{failed_oids};
+    my $snmp_errors = $host->{status}{snmp_errors};
+
+    # Add the host config's errors to its global status data
+    for my $error (@$failed_oids) {
+        push(@{$self->status_data->{$host->{name}}{failed_oids}}, $error);
+    }
+    for my $error (@$snmp_errors) {
+        push(@{$self->status_data->{$host->{name}}{snmp_errors}}, $error);
+    }
+}
+
+sub _clear_status {
+    my $self = shift;
+    my $host = shift;
+
+    $self->status_data->{$host->{name}} = {
+        failed_oids => [],
+        snmp_errors => []
+    };
+    $host->{status}{failed_oids} = [];
+    $host->{status}{snmp_errors} = [];
+    $self->logger->debug("Cleared status data for ".$host->{name});
+}
+
+
+sub _write_status_data {
+    my $self = shift;
+
+    # Don't write during the first cycle while status data is empty
     return if $self->first_run;
 
-    # Set dir for writing status files to status_dir defined in simp-poller.pl
-    my $mon_dir = $self->status_dir . $name . '/';
+    # Aggregated hash of status data for each host
+    my %status;
 
-    # Checks if $mon_dir exists or creates it
-    unless (-e $mon_dir) {
+    # Aggregate status data by hostname
+    while (my ($hostname, $status_data) = each(%{$self->status_data})) {
 
-        # Note: If the dir can't be accessed due to permissions, writing will fail
-        $self->logger->error("Could not find dir for monitoring data: $mon_dir");
-        return;
-    }
-
-    # Add filename to the path for writing
-    $mon_dir .= $self->group_name . "_status.json";
-    
-    $self->logger->debug("Writing status file $mon_dir");
-
-    my %mon_data = (
-        timestamp   => time(),
-        failed_oids => '',
-        snmp_errors => '',
-        config      => $self->config->{config_file},
-        interval    => $self->interval
-    );
-
-    # Aggregation of all the error data for each session's failed OIDs
-    my $failed_oids = {};
-    # Aggregation of each session's SNMP errors
-    # Note: The community and version subsections are deprecated by config validation
-    # They are left in here for backward compatibility with poller-monitoring.
-    my $snmp_errors = {
-        session   => [],
-        community => 0,
-        version   => 0
-    };
-    my $session_errors = $snmp_errors->{session};
-
-    for my $session (@{$host->{sessions}}) {
-        for my $oid (keys($session->{pending_replies})) {
-            $failed_oids->{"$oid:161"} = {
-                timestamp => time() - $self->interval / 2,
-                error     => 'OID_DATA_ERROR',
+        # Init the host in the aggregated status data if needed
+        unless (exists($status{$hostname})) {
+            $status{$hostname} = {
+                timestamp   => time(),
+                failed_oids => {},
+                snmp_errors => {
+                    session   => [],
+                    community => 0,
+                    version   => 0
+                },
+                config      => $self->config->{config_file},
+                interval    => $self->interval
             };
         }
-        for my $oid (keys($session->{failed_oids})) {
-            $failed_oids->{$oid} = $session->{failed_oids}{$oid};
+
+        my $snmp_errors = $status_data->{snmp_errors};
+        push(@{$status{$hostname}{snmp_errors}{session}}, @$snmp_errors);
+      
+        my $failed_oids = $status_data->{failed_oids};
+        for my $oid_err (@$failed_oids) {
+            $status{$hostname}{failed_oids}{$oid_err->{oid}} = $oid_err;
         }
-        push(@{$session_errors}, $session->{errors}{session}) if ($session->{errors}{session});
     }
 
-    $mon_data{snmp_errors} = $snmp_errors;
-    $mon_data{failed_oids} = $failed_oids;
+    # Write the aggregated status data
+    while (my ($hostname, $status_data) = each(%status)) {
 
-    # Write out the status file
-    if (open(my $fh, '>:encoding(UTF-8)', $mon_dir)) {
-        print $fh JSON->new->pretty->encode(\%mon_data);
-        close($fh) || $self->logger->error("Could not close $mon_dir");
-    }
-    else {
-        $self->logger->error("Could not open " . $mon_dir);
-        return;
-    }
+        # Get the path of the host's status dir and status filename
+        my $host_dir  = $self->status_dir . $hostname . '/';
+        my $host_file = $host_dir . $self->group_name . '_status.json';
+        $self->logger->debug("Writing status file: $host_file");
 
-    $self->logger->debug("Writing completed for status file $mon_dir");
+        # Check that the host's status dir exists and is accessible
+        unless (-e $host_dir) {
+            $self->logger->error("Could not find dir for monitoring data: $host_dir");
+            return;
+        }
+
+        # Write out the status file
+        if (open(my $fh, '>:encoding(UTF-8)', $host_file)) {
+            print $fh JSON->new->pretty->encode($status_data);
+            close($fh) || $self->logger->error("Could not close $host_file");
+        }
+        else {
+            $self->logger->error("Could not open $host_file");
+        }
+    }
 }
 
 
@@ -679,8 +670,11 @@ sub _collect_data {
     my $oids      = $self->oids;
     my $timestamp = time;
 
-    $self->logger->debug("----  START OF POLLING CYCLE FOR: \"" . $self->worker_name . "\"  ----");
 
+    # Write status data for the previous polling cycle
+    $self->_write_status_data();
+
+    $self->logger->debug("----  START OF POLLING CYCLE FOR: \"" . $self->worker_name . "\"  ----");
     $self->logger->debug(sprintf(
         "%s - %s hosts and %s oids per host, max outstanding scaled to %s and queue is %s to %s",
         $self->worker_name,
@@ -690,106 +684,127 @@ sub _collect_data {
         $AnyEvent::SNMP::MIN_RECVQUEUE,
         $AnyEvent::SNMP::MAX_RECVQUEUE
     ));
-       
+    
     for my $host (@$hosts) {
 
-        my $host_name = $host->{name};
-
-        # Retrieve any context IDs if present
-        my $context_ids = $host->{contexts} if (exists($host->{contexts}));
+        my $ip           = $host->{ip};
+        my $name         = $host->{name};
+        my $port         = $host->{port};
+        my $context      = $host->{context};
+        my $status       = $host->{status};
+        my $snmp_session = $host->{snmp_session};
 
         # Used to stagger each request to a specific host, spread load.
         # This does mean you can't collect more OID bases than your interval
         my $delay = 0;
 
-        # Write mon data out for the host's last completed poll cycle
-        $self->_write_mon_data($host, $host_name);
+        # Reset the host status before new requests are made
+        $self->_clear_status($host);
 
-        for my $session (@{$host->{sessions}}) {
+        # Log error and skip collections if there are still pending replies
+        if (keys($status->{'pending_replies'})) {
+            $self->logger->info(sprintf(
+                "%s - Unable to query device %s:%s in poll cycle, remaining oids: %s",
+                $self->worker_name,
+                $ip,
+                $name,
+                Dumper($status->{pending_replies})
+            ));
+            for my $oid (keys(%{$status->{pending_replies}})) {
+                my $error_data = {
+                    oid         => $oid,
+                    error       => 'OID_DATA_ERROR',
+                    description => "No data returned for $oid within polling interval",
+                    timestamp   => time() - $self->interval / 2,
+                };
+                push(@{$status->{failed_oids}}, $error_data);
+            }
+            next;
+        }
 
-            # Reset the failed OIDs for each session after writing the status
-            $session->{failed_oids} = {};
+        # Check the status of the SNMP session
+        if (!defined($snmp_session)) {
+            my $error = $self->worker_name." - No SNMP session defined for ".$name;
+            my $error_data = {
+                type        => 'session',
+                description => $error,
+                error       => $error,
+                timestamp   => time()
+            };
+            push(@{$status->{snmp_errors}}, $error_data);
+            $self->logger->error($error);
 
-            # Log error and skip collections for the session if it has an
-            # OID key in pending response with a val of 1
-            if (scalar(keys %{$session->{'pending_replies'}}) > 0) {
-                $self->logger->info(sprintf(
-                    "%s - Unable to query device %s:%s in poll cycle, remaining oids: %s",
+            # Skip when no SNMP session exists to prevent further failures
+            next;
+        }
+
+        # Initiate an SNMP request for each OID
+        for my $oid_attr (@$oids) {
+
+            my $oid = $oid_attr->{oid};
+
+            # Determine which SNMPGET method we should use
+            my $snmp_method = $oid_attr->{single} ? "get_request" : "get_table";
+
+            # Create a hash of arguments for the request
+            my %args = (-delay => $delay++);
+            if (exists($oid_attr->{single})) {
+                $args{-varbindlist} = [$oid];
+            }
+            else {
+                $args{-baseoid}        = $oid;
+                $args{-maxrepetitions} = $self->request_size;
+            }
+
+            # Add the context to session args if present
+            if (exists($host->{context})) {
+                $args{'-contextengineid'} = $host->{context};
+            }
+
+            # Define the callback with params for the session args
+            $args{'-callback'} = sub {
+                $self->_poll_cb(
+                    host   => $host,
+                    time   => $timestamp,
+                    oid    => $oid,
+                );
+            }; 
+
+            # Use the SNMP session to request data using our args
+            $self->logger->debug(sprintf(
+                "%s - Issuing %s request for %s:%s -> %s",
+                $self->worker_name,
+                $snmp_method, 
+                $name,
+                $port,
+                $oid
+            ));
+
+            my $res = $snmp_session->$snmp_method(%args);
+            if ($res) {
+                # Add the OID to pending replies if the request succeeded
+                $status->{pending_replies}{$oid} = 1;
+            }
+            else {
+                # Add oid and info to failed_oids if it failed during request
+                my $error = sprintf(
+                    "%s - %s request to %s:%s for %s failed: %s",
                     $self->worker_name,
-                    $host->{ip},
-                    $host_name,
-                    Dumper($session->{pending_replies})
-                ));
-                next;
-            }
+                    $snmp_method,
+                    $name,
+                    $port,
+                    $oid,
+                    $snmp_session->error()
+                );
+                $self->logger->error($error);
 
-            # Get the open SNMP session object
-            my $snmp_session = $session->{session};
-
-            if (!defined($snmp_session)) {
-                $self->logger->error($self->worker_name . " - No SNMP session defined for $host_name");
-                next;
-            }
-
-            for my $oid_attr (@$oids) {
-
-                my $oid     = $oid_attr->{oid};
-                my $is_leaf = $oid_attr->{single} || 0;
-
-                my $reqstr = " $oid -> $host->{ip}:$session->{port} ($host_name)";
-
-                # Determine which SNMPGET method we should use
-                my $get_method = $is_leaf ? "get_request" : "get_table";
-
-                # Iterate through the the provided set of base OIDs to collect
-                my $res;
-                my $res_err = sprintf("%s - Unable to issue Net::SNMP method \"%s\"", $self->worker_name, $get_method);
-
-                # Create a hash of arguments for the request
-                my %args = (-delay => $delay++);
-                if ($is_leaf) {
-                    $args{-varbindlist} = [$oid];
-                }
-                else {
-                    $args{-baseoid}        = $oid;
-                    $args{-maxrepetitions} = $self->request_size;
-                }
-
-                # Add the context to session args if present
-                if (exists($session->{context})) {
-                    $args{'-contextengineid'} = $session->{context};
-                }
-
-                # Define the callback with params for the session args
-                $args{'-callback'} = sub {
-                    $self->_poll_cb(
-                        session    => $session,
-                        time       => $timestamp,
-                        name       => $host_name,
-                        ip         => $host->{ip},
-                        oid        => $oid,
-                        reqstr     => $reqstr,
-                        vars       => $host->{host_variable}
-                    );
-                }; 
-
-                # Use the SNMP session to request data using our args
-                $self->logger->debug(sprintf("%s - %s request for %s", $self->worker_name, $get_method, $reqstr));
-                $res = $snmp_session->$get_method(%args);
-
-                if ($res) {
-                    # Add the OID to pending replies if the request succeeded
-                    $session->{pending_replies}{$oid} = 1;
-                }
-                else {
-                    # Add oid and info to failed_oids if it failed during request
-                    $session->{'failed_oids'}{"$oid:$session->{port}"} = {
-                        error       => "OID_REQUEST_ERROR",
-                        description => $snmp_session->error(),
-                        timestamp   => time()
-                    };
-                    $self->logger->error(sprintf("%s - %s: %s", $self->worker_name, $res_err, $snmp_session->error()));
-                }
+                my $error_data = {
+                    oid         => $oid,
+                    error       => 'OID_REQUEST_ERROR',
+                    description => $error,
+                    timestamp   => time()
+                };
+                push(@{$status->{failed_oids}}, $error_data);
             }
         }
     }

--- a/lib/GRNOC/Simp/TSDS.pm
+++ b/lib/GRNOC/Simp/TSDS.pm
@@ -3,7 +3,7 @@ package GRNOC::Simp::TSDS;
 use strict;
 use warnings;
 
-our $VERSION = '1.10.0';
+our $VERSION = '1.11.0';
 
 =head1 NAME
 

--- a/simp-comp.spec
+++ b/simp-comp.spec
@@ -1,6 +1,6 @@
 Summary: A system for fetching data from simp and compiling the data into a composite
 Name: simp-comp
-Version: 1.10.0
+Version: 1.11.0
 Release: 1%{dist}
 License: GRNOC
 Group: GRNOC

--- a/simp-data.spec
+++ b/simp-data.spec
@@ -1,6 +1,6 @@
 Summary: A small system for fetching SNMP data from redis and returning it via RabbitMQ
 Name: simp-data
-Version: 1.10.0
+Version: 1.11.0
 Release: 1%{dist}
 License: GRNOC
 Group: GRNOC

--- a/simp-monitor.spec
+++ b/simp-monitor.spec
@@ -1,5 +1,5 @@
 Name: simp-monitor
-Version: 1.10.0
+Version: 1.11.0
 Release: 1%{?dist}
 Summary: A functionality to monitor SIMP
 License: GRNOC

--- a/simp-poller.spec
+++ b/simp-poller.spec
@@ -1,6 +1,6 @@
 Summary: A small system for gathering large amounts of SNMP data and pushing them into redis
 Name: simp-poller
-Version: 1.10.0
+Version: 1.11.0
 Release: 1%{dist}
 License: GRNOC
 Group: GRNOC

--- a/simp-tsds.spec
+++ b/simp-tsds.spec
@@ -26,6 +26,7 @@ Requires: perl(Parallel::ForkManager)
 Requires: perl(POSIX)
 Requires: perl(Proc::Daemon)
 Requires: perl(Types::Standard)
+Requires: perl-Syntax-Keyword-Try
 Requires: perl(GRNOC::Config)
 Requires: perl(GRNOC::WebService::Client)
 Requires: perl(GRNOC::RabbitMQ) >= 1.2.2

--- a/simp-tsds.spec
+++ b/simp-tsds.spec
@@ -1,6 +1,6 @@
 Summary: SIMP TSDS Collector
 Name: simp-tsds
-Version: 1.10.0
+Version: 1.11.0
 Release: 1%{dist}
 License: APL 2.0
 Group: Network


### PR DESCRIPTION
* Added simp-poller support for multiple host configurations for a single host
* Added simp-poller support for all Net::SNMP parameters
* Added simp-poller support for logging group worker configuration parameters at startup
* Improved simp-poller worker configuration handling
* Improved simp-poller worker balancing in preparation for automatic worker scaling
* Fixed issue where simp-poller would not allow remote Redis server configuration
* Fixed issue where simp-poller would not properly identify failing SNMP requests for status monitoring
* Fixed issue where simp-poller would discard status monitoring data for hosts with multiple SNMP configurations
* Fixed issue where simp-poller would spawn zombie workers with no hosts configured for their group
* Fixed issue where simp-poller would ignore additional configurations for the same host
* Fixed issue where simp-tsds would fail while encoding JSON
* Deprecated simp-poller "use_unix_socket" flag, now implied by the specification of a "unix_socket"