### PR TITLE
SCTASK0111949 - SIMP-TSDS Workers Bugfix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME=simp
-VERSION=1.11.2
+VERSION=1.11.3
 
 .PHONY: dist
 

--- a/lib/GRNOC/Simp/Comp.pm
+++ b/lib/GRNOC/Simp/Comp.pm
@@ -15,7 +15,7 @@ use GRNOC::Config;
 use GRNOC::Log;
 use GRNOC::Simp::Comp::Worker;
 
-our $VERSION = '1.11.2';
+our $VERSION = '1.11.3';
 
 ### REQUIRED ATTRIBUTES ###
 

--- a/lib/GRNOC/Simp/Data.pm
+++ b/lib/GRNOC/Simp/Data.pm
@@ -13,7 +13,7 @@ use GRNOC::Config;
 use GRNOC::Log;
 use GRNOC::Simp::Data::Worker;
 
-our $VERSION = '1.11.2';
+our $VERSION = '1.11.3';
 
 =head2 public attributes
 =over 12

--- a/lib/GRNOC/Simp/Poller.pm
+++ b/lib/GRNOC/Simp/Poller.pm
@@ -15,7 +15,7 @@ use GRNOC::Config;
 use GRNOC::Log;
 use GRNOC::Simp::Poller::Worker;
 
-our $VERSION = '1.11.2';
+our $VERSION = '1.11.3';
 
 ### Required Attributes ###
 =head2 public attributes

--- a/lib/GRNOC/Simp/TSDS.pm
+++ b/lib/GRNOC/Simp/TSDS.pm
@@ -3,7 +3,7 @@ package GRNOC::Simp::TSDS;
 use strict;
 use warnings;
 
-our $VERSION = '1.11.2';
+our $VERSION = '1.11.3';
 
 =head1 NAME
 

--- a/lib/GRNOC/Simp/TSDS/Master.pm
+++ b/lib/GRNOC/Simp/TSDS/Master.pm
@@ -511,22 +511,10 @@ sub _create_worker
         },
         code => sub {
             $worker->start();
-        },
-        delegates => ['StandardHandles', 'PrintError']
+        }
     );
     # Start worker, 
     my $proc = $init_proc->run();
-
-    # Register delegate handlers for the AE::Subprocess::Run instances
-    # This is a way to ensure fork logging works.
-    $proc->delegate('stdout')->handle->push_read(line => sub {
-        my ($h, $line) = @_;
-        $self->logger->info($line);
-    });
-    $proc->delegate('stderr')->handle->push_read(line => sub {
-        my ($h, $line) = @_;
-        $self->logger->error($line);
-    });
 
     $self->worker_patterns->{$proc->child_pid} = $worker;
     push(@{$self->children}, $proc);

--- a/lib/GRNOC/Simp/TSDS/Master.pm
+++ b/lib/GRNOC/Simp/TSDS/Master.pm
@@ -510,7 +510,7 @@ sub _create_worker
         },
         code => sub {
             $worker->start();
-        }
+        },
         delegates => ['StandardHandles', 'PrintError']
     );
     # Start worker, 
@@ -518,11 +518,11 @@ sub _create_worker
 
     # Register delegate handlers for the AE::Subprocess::Run instances
     # This is a way to ensure fork logging works.
-    $proc->delegate->('stdout')->handle->push_read(line => sub {
+    $proc->delegate('stdout')->handle->push_read(line => sub {
         my ($h, $line) = @_;
         $self->logger->info($line);
     });
-    $proc->delegate->('stderr')->handle->push_read(line => sub {
+    $proc->delegate('stderr')->handle->push_read(line => sub {
         my ($h, $line) = @_;
         $self->logger->error($line);
     });

--- a/lib/GRNOC/Simp/TSDS/Master.pm
+++ b/lib/GRNOC/Simp/TSDS/Master.pm
@@ -507,9 +507,22 @@ sub _create_worker
         code => sub {
             $worker->start();
         }
+        delegates => ['StandardHandles', 'PrintError']
     );
     # Start worker, 
     my $proc = $init_proc->run();
+
+    # Register delegate handlers for the AE::Subprocess::Run instances
+    # This is a way to ensure fork logging works.
+    $proc->delegate->('stdout')->handle->push_read(line => sub {
+        my ($h, $line) = @_;
+        $self->logger->info($line);
+    });
+    $proc->delegate->('stderr')->handle->push_read(line => sub {
+        my ($h, $line) = @_;
+        $self->logger->error($line);
+    });
+
     $self->worker_patterns->{$proc->child_pid} = $worker;
     push(@{$self->children}, $proc);
 }

--- a/lib/GRNOC/Simp/TSDS/Master.pm
+++ b/lib/GRNOC/Simp/TSDS/Master.pm
@@ -406,7 +406,11 @@ sub _create_workers
         # Will cause an effective 'restart' of master.
         $self->running->send;
     };
-
+    # Handler for unexpected errors or exceptions that result in process termination
+    $SIG{'__DIE__'} = sub {
+        my $error = shift;
+        $self->logger->error(sprintf("Error: %s (PID %s) died unexpectedly: %s", $0, $$, $error));
+    };
 }
 
 # Creates workers for a single collection

--- a/lib/GRNOC/Simp/TSDS/Pusher.pm
+++ b/lib/GRNOC/Simp/TSDS/Pusher.pm
@@ -155,7 +155,7 @@ sub push {
     }
     # Handle abnormal response formats
     elsif (ref($res) ne 'HASH') {
-        $error = sprintf("[%s] Error: Abnormal response of type %s from push.cgi", self->worker_name, ref($res));
+        $error = sprintf("[%s] Error: Abnormal response of type %s from push.cgi", $self->worker_name, ref($res));
         $self->logger->error($error);
         return {'error' => 1, 'error_text' => $error};
     }

--- a/lib/GRNOC/Simp/TSDS/Pusher.pm
+++ b/lib/GRNOC/Simp/TSDS/Pusher.pm
@@ -85,58 +85,85 @@ sub BUILD
 sub push {
     my ($self, $msg_list) = @_;
 
-    # Return early if there are no messages to send
+    # Initialize a response and error.
+    my $res;
+    my $error;
+
+    # Return the default success response if there are no messages.
     if (scalar(@$msg_list) < 1) {
         $self->logger->info(sprintf("[%s] Nothing to push to TSDS", $self->worker_name));
-        return;
+        return {'error' => 0, 'error_text' => ''};
     };
 
-    my $res;
+    # Try pushing the data to TSDS.
     try {
-        # Add the block of messages to TSDS using push.cgi
         $res = $self->tsds_svc->add_data(data => encode_json($msg_list));
     }
     catch ($e) {
-        $self->logger->error(sprintf(
-            '[%s] Could not push data to TSDS: %s',
-            $self->worker_name,
-            $e
-        ));
+        $error = sprintf("[%s] Error: Exception while pushing data to TSDS: %s", $self->worker_name, $e);
+        $self->logger->error($error);
+
+        # Return a response hashref with the error.
+        return {'error' => 1, 'error_text' => $error};
     };
 
-    # Check the response from TSDS
-    if (!defined($res) || $res->{'error'}) {
+    # Handle an undefined response.
+    if (!defined($res)) {
+        $error = sprintf("[%s] Error: No response from TSDS push.cgi", $self->worker_name);
 
-        my $error = sprintf(
-            "[%s] Error pushing to TSDS: %s",
-            $self->worker_name,
-            GRNOC::Simp::TSDS::error_message($res)
-        );
+        # Return a response hashref with the error.
+        return {'error' => 1, 'error_text' => $error};
+    }
+    # Handle normal response errors.
+    elsif (ref($res) eq 'HASH' && exists($res->{'error'}) && $res->{'error'}) {
+        $error = sprintf("[%s] Error: Response from TSDS push.cgi had errors", $self->worker_name);
 
-        # Check whether the issue was sending a message that has invalid characters
-        if ($res && $res->{error_text} && $res->{error_text} =~ m/only accepts printable characters/g) {
+        # Some response errors will include a message
+        if (exists($res->{'error_text'}) && defined($res->{'error_text'})) {
+            $error = sprintf("%s: %s", $error, $res->{'error_text'});
 
-            # Track individual bad messages to dump in the error log
-            my @bad;
+            # Check whether the issue was sending a message that has invalid characters.
+            # Try re-sending the data one message at a time if so.
+            # Can't recurse push() on individual messages, a bad message will always fail.
+            if ($res->{'error_text'} =~ m/only accepts printable characters/g) {
+                $error = sprintf("[%s] Error: Message with bad characters encountered, pushing messages individually", $self->worker_name);
 
-            # Try sending each message individually in-case only one had character issues
-            for my $msg (@$msg_list) {
-                $res = $self->tsds_svc->add_data(data => encode_json([$msg]));
-                if (!defined($res) || $res->{error}) {
-                    push(@bad, $msg);
+                my @bad_messages;
+
+                for my $msg (@$msg_list) {
+                    try {
+                        $res = $self->tsds_svc->add_data(data => encode_json([$msg]));
+                    }
+                    catch ($e) {
+                        $self->logger->error(sprintf("[%s] Error: Exception while retrying individual message push to TSDS: %s", $self->worker_name, $e));
+                    };
+
+                    # A message is bad unless it gets a normal response without errors.
+                    unless (defined($res) && ref($res) eq 'HASH' && !$res->{'error'}) {
+                        $self->logger->error(sprintf("[%s] Error: Found a bad message after retry: %s", $self->worker_name, Dumper($msg)));
+                        push(@bad_messages, $msg);
+                    }
                 }
-            }
 
-            # Update the error message
-            $error .= " - %s out of %s total messages contained invalid characters: %s";
-            $error = sprintf($error, scalar(@bad), scalar(@$msg_list), Dumper(\@bad));
-        } else {
-            # Missing response should be reported as error i.e. connection refused by RabbitMQ
-            $res = {'error' => $error};
+                # Update the error message
+                $error .= ": %s out of %s total messages contained invalid characters";
+                $error = sprintf($error, scalar(@bad_messages), scalar(@$msg_list));
+            }
         }
         $self->logger->error($error);
+        return {'error' => 1, 'error_text' => $error};
     }
-    # Return hash ref for worker's status log
+    # Handle abnormal response formats
+    elsif (ref($res) ne 'HASH') {
+        $error = sprintf("[%s] Error: Abnormal response of type %s from push.cgi", self->worker_name, ref($res));
+        $self->logger->error($error);
+        return {'error' => 1, 'error_text' => $error};
+    }
+
+    # Force the error and error_text keys if they don't exist for some reason
+    $res->{'error'} = 0 unless (exists($res->{'error'}));
+    $res->{'error_text'} = '' unless(exists($res->{'error_text'}));
+
     return $res;
 }
 

--- a/lib/GRNOC/Simp/TSDS/Worker.pm
+++ b/lib/GRNOC/Simp/TSDS/Worker.pm
@@ -453,6 +453,8 @@ sub _write_push_status {
     my $error = (defined($res) && $res->{'error'}) ? 1 : 0;
     my $error_txt = ($error eq 1) ? $res->{'error_text'} : "";
  
+    # Status writing is wrapped in try/catch for i/o exceptions.
+    # Both the master and worker access the same file without locking.
     try {
         my $write_res = write_service_status(
             path => $path,

--- a/lib/GRNOC/Simp/TSDS/Worker.pm
+++ b/lib/GRNOC/Simp/TSDS/Worker.pm
@@ -131,6 +131,12 @@ sub start {
     # Create and set the logger
     $self->_set_logger(Log::Log4perl->get_logger('GRNOC.Simp.TSDS.Worker'));
 
+    # Handler for unexpected errors or exceptions that result in process termination
+    $SIG{'__DIE__'} = sub {
+        my $error = shift;
+        $self->logger->error(sprintf("Error: %s (PID %s) died unexpectedly: %s", $0, $$, $error));
+    };
+
     # Add worker PID to the path passed in by master
     $self->_set_status_filepath(sprintf("%s/%s-%s-", $self->status_filepath, $$, $self->worker_name));
     # Initialize status file

--- a/lib/GRNOC/Simp/TSDS/Worker.pm
+++ b/lib/GRNOC/Simp/TSDS/Worker.pm
@@ -432,7 +432,7 @@ sub _push_data {
     my $res;
     while (my @block = $iterator->()) {
         $res = $self->tsds_pusher->push(\@block);
-        if ( defined($res) && $res->{'error'} ) { 
+        if (!defined($res) || (ref($res) eq 'HASH' && exists($res->{'error'}) && $res->{'error'})) {
             $last_failure = $res;
         }
     }
@@ -448,8 +448,9 @@ sub _write_push_status {
     my $res = shift;
 
     my $path = $self->status_filepath;
+    
     my $error = (defined($res) && $res->{'error'}) ? 1 : 0;
-    my $error_txt = ($error eq 1) ? $res->{'error'} : "";
+    my $error_txt = ($error eq 1) ? $res->{'error_text'} : "";
  
     my $write_res = write_service_status(
         path => $path,

--- a/spec/simp-comp.spec
+++ b/spec/simp-comp.spec
@@ -1,6 +1,6 @@
 Summary: A system for fetching data from simp and compiling the data into a composite
 Name: simp-comp
-Version: 1.11.2
+Version: 1.11.3
 Release: 1%{dist}
 License: GRNOC
 Group: GRNOC

--- a/spec/simp-data.spec
+++ b/spec/simp-data.spec
@@ -1,6 +1,6 @@
 Summary: A small system for fetching SNMP data from redis and returning it via RabbitMQ
 Name: simp-data
-Version: 1.11.2
+Version: 1.11.3
 Release: 1%{dist}
 License: GRNOC
 Group: GRNOC

--- a/spec/simp-poller.spec
+++ b/spec/simp-poller.spec
@@ -1,6 +1,6 @@
 Summary: A small system for gathering large amounts of SNMP data and pushing them into redis
 Name: simp-poller
-Version: 1.11.2
+Version: 1.11.3
 Release: 1%{dist}
 License: GRNOC
 Group: GRNOC

--- a/spec/simp-tsds.spec
+++ b/spec/simp-tsds.spec
@@ -1,6 +1,6 @@
 Summary: SIMP TSDS Collector
 Name: simp-tsds
-Version: 1.11.2
+Version: 1.11.3
 Release: 1%{dist}
 License: APL 2.0
 Group: Network


### PR DESCRIPTION
- Resolves a bug where simp-tsds worker processes die unexpectedly after an abnormal response from the TSDS push client during an httpd (apache) failure.
- Resolves bugs caused when simp-tsds worker status file writing and master parsing file i/o overlap.
- Resolves a bug where simp-tsds status file operations encounter an unhandled exception in the GRNOC::Monitoring::Status dependency.
- Improves logging visibility for exceptions encountered by simp-tsds.